### PR TITLE
[#35] 戒名をノードに表示

### DIFF
--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -39,10 +39,12 @@ export function PersonNode({ node, person }: Props): React.ReactNode {
   const fill = theme.sexFill[toSex(person.sex)];
   const fullName = `${person.familyName} ${person.givenName}`;
   const dateText = buildDateText(person.birth, person.death);
+  const posthumousName = person.posthumousName ?? '';
   const transform = `translate(${node.x.toString()}, ${node.y.toString()})`;
   const centerX = node.width / 2;
-  const nameY = (node.height / 2) - 4;
-  const dateY = (node.height / 2) + 14;
+  const nameY = 22;
+  const dateY = 42;
+  const posthumousY = 60;
   return (
     <g transform={transform}>
       <rect
@@ -76,6 +78,20 @@ export function PersonNode({ node, person }: Props): React.ReactNode {
             y={dateY}
           >
             {dateText}
+          </text>
+        )}
+
+      {posthumousName === ''
+        ? null
+        : (
+          <text
+            fill={theme.dateFill}
+            fontSize={10}
+            textAnchor="middle"
+            x={centerX}
+            y={posthumousY}
+          >
+            {posthumousName}
           </text>
         )}
     </g>

--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -8,6 +8,10 @@ interface Props {
   person: Person;
 }
 
+const NAME_Y_RATIO = 0.29;
+const DATE_Y_RATIO = 0.55;
+const POSTHUMOUS_Y_RATIO = 0.79;
+
 function yearOf(date: string): string {
   return date === '' ? '' : date.slice(0, 4);
 }
@@ -39,12 +43,12 @@ export function PersonNode({ node, person }: Props): React.ReactNode {
   const fill = theme.sexFill[toSex(person.sex)];
   const fullName = `${person.familyName} ${person.givenName}`;
   const dateText = buildDateText(person.birth, person.death);
-  const posthumousName = person.posthumousName ?? '';
+  const posthumousName = (person.posthumousName ?? '').trim();
   const transform = `translate(${node.x.toString()}, ${node.y.toString()})`;
   const centerX = node.width / 2;
-  const nameY = 22;
-  const dateY = 42;
-  const posthumousY = 60;
+  const nameY = node.height * NAME_Y_RATIO;
+  const dateY = node.height * DATE_Y_RATIO;
+  const posthumousY = node.height * POSTHUMOUS_Y_RATIO;
   return (
     <g transform={transform}>
       <rect

--- a/src/components/familyTree/layout/internalTypes.ts
+++ b/src/components/familyTree/layout/internalTypes.ts
@@ -6,7 +6,7 @@ import {
 } from '@/components/familyTree/types';
 
 export const PERSON_WIDTH = 120;
-export const PERSON_HEIGHT = 64;
+export const PERSON_HEIGHT = 76;
 export const GENERATION_GAP = 80;
 export const UNIT_GAP = 32;
 export const COUPLE_GAP = 16;


### PR DESCRIPTION
## Summary
- `posthumousName` が設定されている人物について、家系図のノード下部に戒名を表示
- ノード高さを 64 → 76 に拡張して 3 行表示 (氏名 / 生没年 / 戒名) に対応

## Test plan
- [ ] `yarn dev` で起動
- [ ] `sample/family-tree.json` を読み込み
- [ ] 山田 太郎のノードに戒名「釋浄信」が表示されることを確認
- [ ] 戒名がない人物のノードは戒名行が表示されないことを確認

Closes #35