### PR TITLE
[#36] 故人をノードの薄さで視覚的に区別する

### DIFF
--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -11,7 +11,8 @@ interface Props {
 const NAME_Y_RATIO = 0.29;
 const DATE_Y_RATIO = 0.55;
 const POSTHUMOUS_Y_RATIO = 0.79;
-const DECEASED_OPACITY = 0.55;
+const DECEASED_RECT_OPACITY = 0.45;
+const DECEASED_TEXT_OPACITY = 0.75;
 
 function yearOf(date: string): string {
   return date === '' ? '' : date.slice(0, 4);
@@ -46,27 +47,29 @@ export function PersonNode({ node, person }: Props): React.ReactNode {
   const dateText = buildDateText(person.birth, person.death);
   const posthumousName = (person.posthumousName ?? '').trim();
   const isDeceased = person.death !== '';
+  const rectOpacity = isDeceased ? DECEASED_RECT_OPACITY : 1;
+  const textOpacity = isDeceased ? DECEASED_TEXT_OPACITY : 1;
   const transform = `translate(${node.x.toString()}, ${node.y.toString()})`;
   const centerX = node.width / 2;
   const nameY = node.height * NAME_Y_RATIO;
   const dateY = node.height * DATE_Y_RATIO;
   const posthumousY = node.height * POSTHUMOUS_Y_RATIO;
   return (
-    <g
-      opacity={isDeceased ? DECEASED_OPACITY : 1}
-      transform={transform}
-    >
+    <g transform={transform}>
       <rect
         fill={fill}
+        fillOpacity={rectOpacity}
         height={node.height}
         rx={4}
         stroke={theme.nodeStroke}
+        strokeOpacity={rectOpacity}
         strokeWidth={1}
         width={node.width}
       />
 
       <text
         fill={theme.nameFill}
+        fillOpacity={textOpacity}
         fontSize={14}
         fontWeight={600}
         textAnchor="middle"
@@ -81,6 +84,7 @@ export function PersonNode({ node, person }: Props): React.ReactNode {
         : (
           <text
             fill={theme.dateFill}
+            fillOpacity={textOpacity}
             fontSize={11}
             textAnchor="middle"
             x={centerX}
@@ -95,6 +99,7 @@ export function PersonNode({ node, person }: Props): React.ReactNode {
         : (
           <text
             fill={theme.dateFill}
+            fillOpacity={textOpacity}
             fontSize={10}
             textAnchor="middle"
             x={centerX}

--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -11,6 +11,7 @@ interface Props {
 const NAME_Y_RATIO = 0.29;
 const DATE_Y_RATIO = 0.55;
 const POSTHUMOUS_Y_RATIO = 0.79;
+const DECEASED_OPACITY = 0.55;
 
 function yearOf(date: string): string {
   return date === '' ? '' : date.slice(0, 4);
@@ -44,13 +45,17 @@ export function PersonNode({ node, person }: Props): React.ReactNode {
   const fullName = `${person.familyName} ${person.givenName}`;
   const dateText = buildDateText(person.birth, person.death);
   const posthumousName = (person.posthumousName ?? '').trim();
+  const isDeceased = person.death !== '';
   const transform = `translate(${node.x.toString()}, ${node.y.toString()})`;
   const centerX = node.width / 2;
   const nameY = node.height * NAME_Y_RATIO;
   const dateY = node.height * DATE_Y_RATIO;
   const posthumousY = node.height * POSTHUMOUS_Y_RATIO;
   return (
-    <g transform={transform}>
+    <g
+      opacity={isDeceased ? DECEASED_OPACITY : 1}
+      transform={transform}
+    >
       <rect
         fill={fill}
         height={node.height}


### PR DESCRIPTION
## Summary
- `death` が設定されている人物のノードを薄く表示し、現存者と一見して区別できるようにする
- 背景 (rect) の `fillOpacity`/`strokeOpacity` を 0.45、テキストの `fillOpacity` を 0.75 にして「故人とわかる」かつ「テキストが読める」を両立

## Test plan
- [ ] `yarn dev` で起動
- [ ] `sample/family-tree.json` を読み込み
- [ ] 山田 太郎・花子 (没年あり) のノードが薄く表示される
- [ ] その他の現存者 (一郎、美咲 等) は通常の濃さで表示される
- [ ] 故人ノード内のテキストが読める
- [ ] ライト/ダーク両モードで識別可能

Closes #36