### PR TITLE
[#37] 同姓の苗字を省略してノード表示

### DIFF
--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -43,7 +43,9 @@ function buildDateText(birth: string, death: string): string {
 export function PersonNode({ node, person }: Props): React.ReactNode {
   const theme = useFamilyTreeTheme();
   const fill = theme.sexFill[toSex(person.sex)];
-  const fullName = `${person.familyName} ${person.givenName}`;
+  const fullName = node.showFamilyName
+    ? `${person.familyName} ${person.givenName}`
+    : person.givenName;
   const dateText = buildDateText(person.birth, person.death);
   const posthumousName = (person.posthumousName ?? '').trim();
   const isDeceased = person.death !== '';

--- a/src/components/familyTree/layout/familyNameVisibility.ts
+++ b/src/components/familyTree/layout/familyNameVisibility.ts
@@ -1,0 +1,18 @@
+import { type ParentLink } from '@/components/familyTree/layout/internalTypes';
+import { type Person } from '@/schemas/personSchema';
+
+export function computeShowFamilyNameMap(
+  people: Person[],
+  childToParents: Map<string, ParentLink[]>,
+): Map<string, boolean> {
+  const familyNameOf = new Map(people.map((p) => [p.id, p.familyName]));
+  const result = new Map<string, boolean>();
+  for (const person of people) {
+    const parents = childToParents.get(person.id) ?? [];
+    const hasSameSurnameParent = parents.some(
+      ({ parentId }) => familyNameOf.get(parentId) === person.familyName,
+    );
+    result.set(person.id, !hasSameSurnameParent);
+  }
+  return result;
+}

--- a/src/components/familyTree/layout/internalTypes.ts
+++ b/src/components/familyTree/layout/internalTypes.ts
@@ -38,6 +38,7 @@ export interface PlacementCtx {
   childrenOfUnit: Map<string, string[]>;
   subtreeWidths: Map<string, number>;
   childToParents: Map<string, ParentLink[]>;
+  showFamilyNameMap: Map<string, boolean>;
   nodes: PersonNodeLayout[];
   marriageEdges: MarriageEdgeLayout[];
   parentGroups: ParentChildrenGroupLayout[];

--- a/src/components/familyTree/layout/placement.ts
+++ b/src/components/familyTree/layout/placement.ts
@@ -26,6 +26,7 @@ function placeUnitPersons(
       y: unitY,
       width: PERSON_WIDTH,
       height: PERSON_HEIGHT,
+      showFamilyName: ctx.showFamilyNameMap.get(pid) ?? true,
     });
     ctx.personPositions.set(pid, {
       x: px,

--- a/src/components/familyTree/layoutFamilyTree.ts
+++ b/src/components/familyTree/layoutFamilyTree.ts
@@ -3,6 +3,7 @@ import {
   buildCoupleUnits,
   buildSingleUnits,
 } from '@/components/familyTree/layout/buildUnits';
+import { computeShowFamilyNameMap } from '@/components/familyTree/layout/familyNameVisibility';
 import { assignUnitGenerations } from '@/components/familyTree/layout/generations';
 import {
   PADDING,
@@ -67,6 +68,7 @@ function createContext(units: Unit[]): {
     childrenOfUnit: new Map(),
     subtreeWidths: new Map(),
     childToParents: new Map(),
+    showFamilyNameMap: new Map(),
     nodes: [],
     marriageEdges: [],
     parentGroups: [],
@@ -94,6 +96,7 @@ export function layoutFamilyTree(
   assignUnitGenerations(allUnits, childToParents);
   const { unitMap, ctx } = createContext(allUnits);
   ctx.childToParents = childToParents;
+  ctx.showFamilyNameMap = computeShowFamilyNameMap(people, childToParents);
   const ownership = computeOwnership(allUnits, unitOfPerson, childToParents);
   ctx.childrenOfUnit = ownership.childrenOfUnit;
   const personMap = new Map(people.map((p) => [p.id, p]));

--- a/src/components/familyTree/types.ts
+++ b/src/components/familyTree/types.ts
@@ -6,6 +6,7 @@ export interface PersonNodeLayout {
   y: number;
   width: number;
   height: number;
+  showFamilyName: boolean;
 }
 
 export interface MarriageEdgeLayout {


### PR DESCRIPTION
## Summary
- 親と同姓の人物のノードでは苗字を省略して名のみ表示する
- 親不在 (ルート世代) または親と他姓の人物 (旧姓で登録された配偶者など) は姓名併記
- 判定ロジック (`computeShowFamilyNameMap`) を `layout/familyNameVisibility.ts` に分離

## Test plan
- [ ] `yarn dev` で起動
- [ ] `sample/family-tree.json` を読み込み
- [ ] 山田 太郎・花子・健 (祖父母・養子、親不在) は「山田 ◯◯」表示
- [ ] 一郎・二郎・三子 (親が山田) は「◯◯」のみ表示
- [ ] 鈴木 美咲・田中 直子・佐藤 健太 (旧姓・親情報なし) は「他姓 ◯◯」表示
- [ ] 山田 翔・さくら・大輔・みらい (両親に山田を含む) は「◯◯」のみ表示

## 関連
旧姓の正式な扱いは別 issue #43 で検討する。

Closes #37