### PR TITLE
[#47] 同じファイルを連続インポートしても反映されない問題を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,8 @@ function App(): React.ReactNode {
 
   const inputRef = React.useRef<HTMLInputElement>(null);
   const handleImportClick = React.useCallback((): void => {
-    if (inputRef.current) {
+    if (inputRef.current !== null) {
+      inputRef.current.value = '';
       inputRef.current.click();
     }
   },


### PR DESCRIPTION
## Summary
- `handleImportClick` でファイル選択ダイアログを開く前に input の `value` を空にすることで、同じファイルを再選択しても `change` イベントが発火するようにした

## Test plan
- [ ] `yarn dev` で起動
- [ ] `sample/family-tree.json` をインポート → 反映される
- [ ] サンプルを編集 (人物を追加/削除 等) した後、同じ `sample/family-tree.json` をもう一度インポート → 元の状態に上書きされる
- [ ] 別のファイルを選択しても従来通り動作する

Closes #47