### PR TITLE
[#51] 家系図のズーム機能

### DIFF
--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -4,11 +4,16 @@ import { ParentChildEdge } from '@/components/familyTree/ParentChildEdge';
 import { PersonNode } from '@/components/familyTree/PersonNode';
 import { SecondaryParentEdge } from '@/components/familyTree/SecondaryParentEdge';
 import { H2 } from '@/components/ui/H2';
+import { PrimaryButton } from '@/components/ui/PrimaryButton';
 import { type Person } from '@/schemas/personSchema';
 import { usePeopleStore } from '@/store/personStore';
 import { useRelationStore } from '@/store/relationStore';
 import { Box, Flex, Text } from '@chakra-ui/react';
 import React from 'react';
+
+const ZOOM_STEP = 1.25;
+const ZOOM_MIN = 0.25;
+const ZOOM_MAX = 4;
 
 interface LayoutSuccess {
   ok: true;
@@ -43,12 +48,67 @@ export function FamilyTree(): React.ReactNode {
       };
     }
   }, [people, relations]);
+  const [zoom, setZoom] = React.useState(1);
+  const handleZoomIn = React.useCallback((): void => {
+    setZoom((z) => Math.min(z * ZOOM_STEP, ZOOM_MAX));
+  }, []);
+  const handleZoomOut = React.useCallback((): void => {
+    setZoom((z) => Math.max(z / ZOOM_STEP, ZOOM_MIN));
+  }, []);
+  const handleZoomReset = React.useCallback((): void => {
+    setZoom(1);
+  }, []);
+  const zoomPercent = Math.round(zoom * 100);
+  const showTree = result.ok && people.length > 0;
 
   return (
     <Flex direction="column">
-      <H2>
-        家系図
-      </H2>
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <H2>
+          家系図
+        </H2>
+
+        {showTree
+          ? (
+            <Flex
+              alignItems="center"
+              gap={2}
+            >
+              <PrimaryButton
+                onClick={handleZoomOut}
+                size="sm"
+              >
+                −
+              </PrimaryButton>
+
+              <Text
+                fontSize="sm"
+                minWidth="50px"
+                textAlign="center"
+              >
+                {zoomPercent.toString()}%
+              </Text>
+
+              <PrimaryButton
+                onClick={handleZoomIn}
+                size="sm"
+              >
+                +
+              </PrimaryButton>
+
+              <PrimaryButton
+                onClick={handleZoomReset}
+                size="sm"
+              >
+                リセット
+              </PrimaryButton>
+            </Flex>
+          )
+          : null}
+      </Flex>
 
       {people.length === 0
         ? (
@@ -68,14 +128,18 @@ export function FamilyTree(): React.ReactNode {
           </Text>
         )}
 
-      {result.ok && people.length > 0
+      {showTree
         ? (
-          <Box overflowX="auto">
+          <Box
+            maxHeight="70vh"
+            overflowX="auto"
+            overflowY="auto"
+          >
             <Flex>
               <Box
                 bg="bg"
                 flexShrink={0}
-                height={`${result.layout.height.toString()}px`}
+                height={`${(result.layout.height * zoom).toString()}px`}
                 left={0}
                 position="sticky"
                 width="64px"
@@ -85,12 +149,12 @@ export function FamilyTree(): React.ReactNode {
                   <Box
                     alignItems="center"
                     display="flex"
-                    height={`${row.height.toString()}px`}
+                    height={`${(row.height * zoom).toString()}px`}
                     justifyContent="center"
                     key={row.y}
                     left={0}
                     position="absolute"
-                    top={`${row.y.toString()}px`}
+                    top={`${(row.y * zoom).toString()}px`}
                     width="100%"
                   >
                     <Text
@@ -105,8 +169,9 @@ export function FamilyTree(): React.ReactNode {
 
               <Box flexShrink={0}>
                 <svg
-                  height={result.layout.height}
-                  width={result.layout.width}
+                  height={result.layout.height * zoom}
+                  viewBox={`0 0 ${result.layout.width.toString()} ${result.layout.height.toString()}`}
+                  width={result.layout.width * zoom}
                 >
                   {result.layout.parentGroups.map((group) => (
                     <ParentChildEdge

--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -78,8 +78,10 @@ export function FamilyTree(): React.ReactNode {
               gap={2}
             >
               <PrimaryButton
+                aria-label="ズームアウト"
                 onClick={handleZoomOut}
                 size="sm"
+                title="ズームアウト"
               >
                 −
               </PrimaryButton>
@@ -93,8 +95,10 @@ export function FamilyTree(): React.ReactNode {
               </Text>
 
               <PrimaryButton
+                aria-label="ズームイン"
                 onClick={handleZoomIn}
                 size="sm"
+                title="ズームイン"
               >
                 +
               </PrimaryButton>

--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -11,9 +11,8 @@ import { useRelationStore } from '@/store/relationStore';
 import { Box, Flex, Text } from '@chakra-ui/react';
 import React from 'react';
 
-const ZOOM_STEP = 1.25;
-const ZOOM_MIN = 0.25;
-const ZOOM_MAX = 4;
+const ZOOM_LEVELS = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0];
+const DEFAULT_ZOOM_INDEX = 3;
 
 interface LayoutSuccess {
   ok: true;
@@ -48,15 +47,16 @@ export function FamilyTree(): React.ReactNode {
       };
     }
   }, [people, relations]);
-  const [zoom, setZoom] = React.useState(1);
+  const [zoomIndex, setZoomIndex] = React.useState(DEFAULT_ZOOM_INDEX);
+  const zoom = ZOOM_LEVELS[zoomIndex];
   const handleZoomIn = React.useCallback((): void => {
-    setZoom((z) => Math.min(z * ZOOM_STEP, ZOOM_MAX));
+    setZoomIndex((i) => Math.min(i + 1, ZOOM_LEVELS.length - 1));
   }, []);
   const handleZoomOut = React.useCallback((): void => {
-    setZoom((z) => Math.max(z / ZOOM_STEP, ZOOM_MIN));
+    setZoomIndex((i) => Math.max(i - 1, 0));
   }, []);
   const handleZoomReset = React.useCallback((): void => {
-    setZoom(1);
+    setZoomIndex(DEFAULT_ZOOM_INDEX);
   }, []);
   const zoomPercent = Math.round(zoom * 100);
   const showTree = result.ok && people.length > 0;

--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -91,7 +91,7 @@ export function FamilyTree(): React.ReactNode {
                 minWidth="50px"
                 textAlign="center"
               >
-                {zoomPercent.toString()}%
+                {`${zoomPercent.toString()}%`}
               </Text>
 
               <PrimaryButton
@@ -165,7 +165,7 @@ export function FamilyTree(): React.ReactNode {
                       color="fg.muted"
                       fontSize="xs"
                     >
-                      第{(row.generation + 1).toString()}世代
+                      {`第${(row.generation + 1).toString()}世代`}
                     </Text>
                   </Box>
                 ))}

--- a/src/components/familyTree/layout/secondaryParents.ts
+++ b/src/components/familyTree/layout/secondaryParents.ts
@@ -8,10 +8,15 @@ import {
 import { findAnchorPersonId } from '@/components/familyTree/layout/ownership';
 import { type SecondaryParentEdgeLayout } from '@/components/familyTree/types';
 
+interface UnitOrigin {
+  leftX: number;
+  y: number;
+}
+
 function getParentUnitOrigin(
   parentUnit: Unit,
   personPositions: Map<string, PersonPosition>,
-): { leftX: number; y: number } | null {
+): UnitOrigin | null {
   const positions = parentUnit.personIds
     .map((pid) => personPositions.get(pid))
     .filter((p): p is PersonPosition => p !== undefined);


### PR DESCRIPTION
## Summary
- 家系図に「+」「-」「リセット」ボタンを追加。25% 〜 400% の範囲でズーム可能
- ズーム倍率を SVG の `width` / `height` に反映し、`viewBox` で内容を自動スケール
- 世代ラベルも位置 (`top`) と高さ (`height`) がズームに連動
- 家系図表示エリアに `maxHeight: 70vh` + `overflowY: auto` を設定し、拡大時にページ全体ではなく枠内でスクロール
- ズームボタンが画面外に出ないように画面上部の H2 と同じ列に配置

## Test plan
- [ ] `yarn dev` で起動
- [ ] `sample/family-tree.json` をインポート
- [ ] 「+」「-」で拡大・縮小、リセットで 100% に戻る
- [ ] 25%・100%・200%・400% で表示が崩れない
- [ ] ズーム後も横スクロール・世代ラベルが正しく機能する
- [ ] 拡大時に家系図エリア内で縦スクロールできる (ページ全体は揺れない)
- [ ] ライト/ダーク両モードで動作

## 既知の今後 (別 issue)
- マウスホイール (Ctrl + ホイール) でのズーム
- タッチデバイスでのピンチズーム

Closes #51