### PR TITLE
[#50] 家系図のノードクリックで人物編集モーダルを開く

### DIFF
--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -3,6 +3,7 @@ import { MarriageEdge } from '@/components/familyTree/MarriageEdge';
 import { ParentChildEdge } from '@/components/familyTree/ParentChildEdge';
 import { PersonNode } from '@/components/familyTree/PersonNode';
 import { SecondaryParentEdge } from '@/components/familyTree/SecondaryParentEdge';
+import { PersonDialog } from '@/components/person/PersonDialog';
 import { H2 } from '@/components/ui/H2';
 import { PrimaryButton } from '@/components/ui/PrimaryButton';
 import { type Person } from '@/schemas/personSchema';
@@ -47,6 +48,18 @@ export function FamilyTree(): React.ReactNode {
       };
     }
   }, [people, relations]);
+  const [editingPersonId, setEditingPersonId] = React.useState<string | null>(null);
+  const editingPerson = editingPersonId === null
+    ? undefined
+    : personMap.get(editingPersonId);
+  const handleNodeClick = React.useCallback((personId: string): void => {
+    setEditingPersonId(personId);
+  }, []);
+  const handleDialogOpenChange = React.useCallback((e: { open: boolean }): void => {
+    if (!e.open) {
+      setEditingPersonId(null);
+    }
+  }, []);
   const [zoomIndex, setZoomIndex] = React.useState(DEFAULT_ZOOM_INDEX);
   const zoom = ZOOM_LEVELS[zoomIndex];
   const handleZoomIn = React.useCallback((): void => {
@@ -207,6 +220,7 @@ export function FamilyTree(): React.ReactNode {
                       <PersonNode
                         key={node.personId}
                         node={node}
+                        onClick={handleNodeClick}
                         person={person}
                       />
                     );
@@ -217,6 +231,17 @@ export function FamilyTree(): React.ReactNode {
           </Box>
         )
         : null}
+
+      {editingPerson === undefined
+        ? null
+        : (
+          <PersonDialog
+            isOpen
+            key={editingPerson.id}
+            onOpenChange={handleDialogOpenChange}
+            person={editingPerson}
+          />
+        )}
     </Flex>
   );
 }

--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 interface Props {
   node: PersonNodeLayout;
+  onClick?: (personId: string) => void;
   person: Person;
 }
 
@@ -40,7 +41,7 @@ function buildDateText(birth: string, death: string): string {
   return `${b} - ${d}`;
 }
 
-export function PersonNode({ node, person }: Props): React.ReactNode {
+export function PersonNode({ node, onClick, person }: Props): React.ReactNode {
   const theme = useFamilyTreeTheme();
   const fill = theme.sexFill[toSex(person.sex)];
   const fullName = node.showFamilyName
@@ -56,8 +57,15 @@ export function PersonNode({ node, person }: Props): React.ReactNode {
   const nameY = node.height * NAME_Y_RATIO;
   const dateY = node.height * DATE_Y_RATIO;
   const posthumousY = node.height * POSTHUMOUS_Y_RATIO;
+  const handleClick = onClick === undefined
+    ? undefined
+    : (): void => { onClick(person.id); };
   return (
-    <g transform={transform}>
+    <g
+      onClick={handleClick}
+      style={onClick === undefined ? undefined : { cursor: 'pointer' }}
+      transform={transform}
+    >
       <rect
         fill={fill}
         fillOpacity={rectOpacity}

--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -57,13 +57,27 @@ export function PersonNode({ node, onClick, person }: Props): React.ReactNode {
   const nameY = node.height * NAME_Y_RATIO;
   const dateY = node.height * DATE_Y_RATIO;
   const posthumousY = node.height * POSTHUMOUS_Y_RATIO;
-  const handleClick = onClick === undefined
+  const isClickable = onClick !== undefined;
+  const handleClick = !isClickable
     ? undefined
     : (): void => { onClick(person.id); };
+  const handleKeyDown = !isClickable
+    ? undefined
+    : (e: React.KeyboardEvent<SVGGElement>): void => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick(person.id);
+      }
+    };
+  const ariaLabel = `${person.familyName} ${person.givenName}`;
   return (
     <g
+      aria-label={isClickable ? ariaLabel : undefined}
       onClick={handleClick}
-      style={onClick === undefined ? undefined : { cursor: 'pointer' }}
+      onKeyDown={handleKeyDown}
+      role={isClickable ? 'button' : undefined}
+      style={isClickable ? { cursor: 'pointer' } : undefined}
+      tabIndex={isClickable ? 0 : undefined}
       transform={transform}
     >
       <rect

--- a/src/components/person/PeopleTable.tsx
+++ b/src/components/person/PeopleTable.tsx
@@ -1,4 +1,4 @@
-import { AddPersonDialog } from '@/components/person/AddPersonDialog';
+import { PersonDialog } from '@/components/person/PersonDialog';
 import { H2 } from '@/components/ui/H2';
 import { PrimaryButton } from '@/components/ui/PrimaryButton';
 import { type Person, sexList } from '@/schemas/personSchema';
@@ -54,7 +54,7 @@ export function PeopleTable(): React.ReactNode {
         </Table.Body>
       </Table.Root>
 
-      <AddPersonDialog
+      <PersonDialog
         isOpen={isOpen}
         key={isOpen.toString()}
         onOpenChange={(e) => { setIsOpen(e.open); }}

--- a/src/components/person/PersonDialog.tsx
+++ b/src/components/person/PersonDialog.tsx
@@ -8,25 +8,17 @@ import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { v4 as uuidv4 } from 'uuid';
 
-interface AddPersonDialogProps {
+interface PersonDialogProps {
   isOpen: boolean;
   onOpenChange: (e: { open: boolean }) => void;
+  person?: Person;
 }
 
-export function AddPersonDialog({ isOpen, onOpenChange }: AddPersonDialogProps): React.ReactNode {
-  const addPerson = usePeopleStore((state) => state.addPerson);
-  const onSubmit = (person: Person): void => {
-    console.log(person);
-    addPerson(person);
-    onOpenChange({ open: false });
-    toaster.create({
-      title: '人物を追加しました。',
-      description: `${person.familyName} ${person.givenName}さんを追加しました。`,
-      type: 'success',
-    });
-  };
-
-  const defaultValues: Person = {
+function buildDefaultValues(person: Person | undefined): Person {
+  if (person !== undefined) {
+    return person;
+  }
+  return {
     id: uuidv4(),
     familyName: '',
     givenName: '',
@@ -37,10 +29,52 @@ export function AddPersonDialog({ isOpen, onOpenChange }: AddPersonDialogProps):
     death: '',
     posthumousName: '',
   };
+}
+
+export function PersonDialog({ isOpen, onOpenChange, person }: PersonDialogProps): React.ReactNode {
+  const addPerson = usePeopleStore((state) => state.addPerson);
+  const updatePerson = usePeopleStore((state) => state.updatePerson);
+  const deletePerson = usePeopleStore((state) => state.deletePerson);
+  const isEdit = person !== undefined;
+  const defaultValues = buildDefaultValues(person);
   const { control, register, handleSubmit, formState: { errors } } = useForm<Person>({
     defaultValues,
     resolver: zodResolver(personSchema),
   });
+  const onSubmit = (data: Person): void => {
+    if (isEdit) {
+      updatePerson(data);
+      toaster.create({
+        title: '人物を更新しました。',
+        description: `${data.familyName} ${data.givenName}さんを更新しました。`,
+        type: 'success',
+      });
+    } else {
+      addPerson(data);
+      toaster.create({
+        title: '人物を追加しました。',
+        description: `${data.familyName} ${data.givenName}さんを追加しました。`,
+        type: 'success',
+      });
+    }
+    onOpenChange({ open: false });
+  };
+  const handleDelete = (): void => {
+    if (person === undefined) {
+      return;
+    }
+    const fullName = `${person.familyName} ${person.givenName}`;
+    if (!window.confirm(`${fullName}さんを削除しますか?`)) {
+      return;
+    }
+    deletePerson(person.id);
+    onOpenChange({ open: false });
+    toaster.create({
+      title: '人物を削除しました。',
+      description: `${fullName}さんを削除しました。`,
+      type: 'success',
+    });
+  };
 
   return (
     <Dialog.Root
@@ -54,7 +88,7 @@ export function AddPersonDialog({ isOpen, onOpenChange }: AddPersonDialogProps):
         <Dialog.Positioner>
           <Dialog.Content>
             <Dialog.Header>
-              人物追加
+              {isEdit ? '人物編集' : '人物追加'}
             </Dialog.Header>
 
             <form onSubmit={handleSubmit(onSubmit)}>
@@ -180,6 +214,19 @@ export function AddPersonDialog({ isOpen, onOpenChange }: AddPersonDialogProps):
               </Dialog.Body>
 
               <Dialog.Footer>
+                {isEdit
+                  ? (
+                    <Button
+                      colorPalette="red"
+                      onClick={handleDelete}
+                      type="button"
+                      variant="outline"
+                    >
+                      削除
+                    </Button>
+                  )
+                  : null}
+
                 <Dialog.ActionTrigger asChild>
                   <Button variant="outline">キャンセル</Button>
                 </Dialog.ActionTrigger>


### PR DESCRIPTION
## Summary
- `AddPersonDialog` を `PersonDialog` にリネームし、optional な `person` prop で **追加 / 編集** の両モードを扱えるように
- 編集モードでは `削除` ボタンを表示 (`window.confirm` で確認)
- `PersonNode` に optional な `onClick` を追加。指定時は `cursor: pointer` と click ハンドラを設定
- `FamilyTree` で `editingPersonId` state を保持し、ノードクリックで編集モーダルを開く

## Test plan
- [ ] `yarn dev` で起動
- [ ] `sample/family-tree.json` を読み込み
- [ ] 家系図のノードをクリックすると「人物編集」モーダルが開く
- [ ] フォームに既存値が表示される
- [ ] 編集して保存 → 家系図に反映される
- [ ] 「削除」ボタン → confirm → 削除される
- [ ] 「キャンセル」「閉じる」で何も変更されない
- [ ] 「人物追加」ボタン (テーブル上部) は従来通り「人物追加」モーダルが開く

## 既知の今後
関係 (parent-child 等) の編集はスコープ外。RelationTable 側に分担する想定。必要なら別 issue で対応。

Closes #50