### PR TITLE
[#53] JSON ファイルの D&D インポート

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { toaster, Toaster } from '@/components/ui/toaster';
 import { importJsonSchema } from '@/schemas/importJsonSchema';
 import { usePeopleStore } from '@/store/personStore';
 import { useRelationStore } from '@/store/relationStore';
-import { Flex, Grid, GridItem, Input } from '@chakra-ui/react';
+import { Box, Flex, Grid, GridItem, Input, Text } from '@chakra-ui/react';
 import React from 'react';
 
 function App(): React.ReactNode {
@@ -23,12 +23,7 @@ function App(): React.ReactNode {
   },
   [people, relations]);
 
-  const handleFileChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>): void => {
-    if (!e.target.files) {
-      return;
-    }
-
-    const file = e.target.files[0];
+  const processFile = React.useCallback((file: File): void => {
     const reader = new FileReader();
     reader.onload = (event): void => {
       try {
@@ -72,6 +67,54 @@ function App(): React.ReactNode {
     reader.readAsText(file);
   }, []);
 
+  const handleFileChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>): void => {
+    if (!e.target.files || e.target.files.length === 0) {
+      return;
+    }
+    processFile(e.target.files[0]);
+  }, [processFile]);
+
+  const [isDragging, setIsDragging] = React.useState(false);
+  const dragCounterRef = React.useRef(0);
+  const handleDragEnter = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+    if (!e.dataTransfer.types.includes('Files')) {
+      return;
+    }
+    dragCounterRef.current += 1;
+    setIsDragging(true);
+  }, []);
+  const handleDragLeave = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+    dragCounterRef.current -= 1;
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0;
+      setIsDragging(false);
+    }
+  }, []);
+  const handleDragOver = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+  }, []);
+  const handleDrop = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+    if (e.dataTransfer.files.length === 0) {
+      return;
+    }
+    const file = e.dataTransfer.files[0];
+    const isJson = file.name.toLowerCase().endsWith('.json') || file.type === 'application/json';
+    if (!isJson) {
+      toaster.create({
+        title: 'インポートに失敗しました。',
+        description: 'JSON ファイルのみ対応しています。',
+        type: 'error',
+      });
+      return;
+    }
+    processFile(file);
+  }, [processFile]);
+
   const inputRef = React.useRef<HTMLInputElement>(null);
   const handleImportClick = React.useCallback((): void => {
     if (inputRef.current !== null) {
@@ -82,7 +125,13 @@ function App(): React.ReactNode {
   []);
 
   return (
-    <>
+    <Box
+      minHeight="100vh"
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
       <Grid
         gap={4}
         templateColumns="repeat(2, minmax(0, 1fr))"
@@ -130,8 +179,34 @@ function App(): React.ReactNode {
         type="file"
       />
 
+      {isDragging
+        ? (
+          <Box
+            alignItems="center"
+            bg="blackAlpha.700"
+            bottom={0}
+            display="flex"
+            justifyContent="center"
+            left={0}
+            pointerEvents="none"
+            position="fixed"
+            right={0}
+            top={0}
+            zIndex={9999}
+          >
+            <Text
+              color="white"
+              fontSize="2xl"
+              fontWeight={600}
+            >
+              JSON ファイルをドロップしてインポート
+            </Text>
+          </Box>
+        )
+        : null}
+
       <Toaster />
-    </>
+    </Box>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,14 @@ import { useRelationStore } from '@/store/relationStore';
 import { Box, Flex, Grid, GridItem, Input, Text } from '@chakra-ui/react';
 import React from 'react';
 
+function isJsonFile(file: File): boolean {
+  return file.name.toLowerCase().endsWith('.json') || file.type === 'application/json';
+}
+
+function isFileDrag(e: React.DragEvent<HTMLDivElement>): boolean {
+  return e.dataTransfer.types.includes('Files');
+}
+
 function App(): React.ReactNode {
   const people = usePeopleStore((state) => state.people);
   const relations = useRelationStore((state) => state.relations);
@@ -24,6 +32,14 @@ function App(): React.ReactNode {
   [people, relations]);
 
   const processFile = React.useCallback((file: File): void => {
+    if (!isJsonFile(file)) {
+      toaster.create({
+        title: 'インポートに失敗しました。',
+        description: 'JSON ファイルのみ対応しています。',
+        type: 'error',
+      });
+      return;
+    }
     const reader = new FileReader();
     reader.onload = (event): void => {
       try {
@@ -77,15 +93,17 @@ function App(): React.ReactNode {
   const [isDragging, setIsDragging] = React.useState(false);
   const dragCounterRef = React.useRef(0);
   const handleDragEnter = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
-    e.preventDefault();
-    if (!e.dataTransfer.types.includes('Files')) {
+    if (!isFileDrag(e)) {
       return;
     }
+    e.preventDefault();
     dragCounterRef.current += 1;
     setIsDragging(true);
   }, []);
   const handleDragLeave = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
-    e.preventDefault();
+    if (!isFileDrag(e)) {
+      return;
+    }
     dragCounterRef.current -= 1;
     if (dragCounterRef.current <= 0) {
       dragCounterRef.current = 0;
@@ -93,26 +111,22 @@ function App(): React.ReactNode {
     }
   }, []);
   const handleDragOver = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
+    if (!isFileDrag(e)) {
+      return;
+    }
     e.preventDefault();
   }, []);
   const handleDrop = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
+    if (!isFileDrag(e)) {
+      return;
+    }
     e.preventDefault();
     dragCounterRef.current = 0;
     setIsDragging(false);
     if (e.dataTransfer.files.length === 0) {
       return;
     }
-    const file = e.dataTransfer.files[0];
-    const isJson = file.name.toLowerCase().endsWith('.json') || file.type === 'application/json';
-    if (!isJson) {
-      toaster.create({
-        title: 'インポートに失敗しました。',
-        description: 'JSON ファイルのみ対応しています。',
-        type: 'error',
-      });
-      return;
-    }
-    processFile(file);
+    processFile(e.dataTransfer.files[0]);
   }, [processFile]);
 
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ function isJsonFile(file: File): boolean {
 }
 
 function isFileDrag(e: React.DragEvent<HTMLDivElement>): boolean {
-  return e.dataTransfer.types.includes('Files');
+  return Array.from(e.dataTransfer.types).includes('Files');
 }
 
 function App(): React.ReactNode {
@@ -41,6 +41,14 @@ function App(): React.ReactNode {
       return;
     }
     const reader = new FileReader();
+    reader.onerror = (): void => {
+      console.error('ファイルの読み込みに失敗しました。');
+      toaster.create({
+        title: 'インポートに失敗しました。',
+        description: 'ファイルの読み込みに失敗しました。',
+        type: 'error',
+      });
+    };
     reader.onload = (event): void => {
       try {
         if (!event.target) {


### PR DESCRIPTION
## Summary
- 画面全体に JSON ファイルをドロップしてインポートできるように
- 既存のファイル処理を `processFile` 関数に切り出し、選択 / D&D 両方から再利用
- ドラッグ中は半透明オーバーレイ + 「JSON ファイルをドロップしてインポート」メッセージ
- 子要素間の `dragLeave` 誤発火を `dragCounter` ref で回避
- JSON 以外がドロップされた場合はエラー toast

## Test plan
- [ ] `yarn dev` で起動
- [ ] JSON ファイルをページにドラッグ → オーバーレイ表示
- [ ] ドロップ → インポートされる
- [ ] JSON 以外 (例: 画像) をドロップ → エラー toast
- [ ] ドラッグキャンセル (Esc / ページ外へ離脱) → オーバーレイが消える
- [ ] 既存の「インポート」ボタンからの選択フローも従来通り動作

Closes #53