### PR TITLE
[#54] 家系図を画像 (PNG/SVG) としてエクスポート

### DIFF
--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -1,3 +1,4 @@
+import { exportAsPng, exportAsSvg } from '@/components/familyTree/exportImage';
 import { layoutFamilyTree } from '@/components/familyTree/layoutFamilyTree';
 import { MarriageEdge } from '@/components/familyTree/MarriageEdge';
 import { ParentChildEdge } from '@/components/familyTree/ParentChildEdge';
@@ -6,6 +7,7 @@ import { SecondaryParentEdge } from '@/components/familyTree/SecondaryParentEdge
 import { PersonDialog } from '@/components/person/PersonDialog';
 import { H2 } from '@/components/ui/H2';
 import { PrimaryButton } from '@/components/ui/PrimaryButton';
+import { toaster } from '@/components/ui/toaster';
 import { type Person } from '@/schemas/personSchema';
 import { usePeopleStore } from '@/store/personStore';
 import { useRelationStore } from '@/store/relationStore';
@@ -60,6 +62,37 @@ export function FamilyTree(): React.ReactNode {
       setEditingPersonId(null);
     }
   }, []);
+  const svgRef = React.useRef<SVGSVGElement>(null);
+  const handleExportSvg = React.useCallback((): void => {
+    if (svgRef.current === null || !result.ok) {
+      return;
+    }
+    exportAsSvg(
+      svgRef.current,
+      result.layout.width,
+      result.layout.height,
+      'family-tree.svg',
+    );
+  }, [result]);
+  const handleExportPng = React.useCallback((): void => {
+    if (svgRef.current === null || !result.ok) {
+      return;
+    }
+    void exportAsPng(
+      svgRef.current,
+      result.layout.width,
+      result.layout.height,
+      'family-tree.png',
+      '#ffffff',
+    ).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      toaster.create({
+        title: 'PNG エクスポートに失敗しました。',
+        description: message,
+        type: 'error',
+      });
+    });
+  }, [result]);
   const [zoomIndex, setZoomIndex] = React.useState(DEFAULT_ZOOM_INDEX);
   const zoom = ZOOM_LEVELS[zoomIndex];
   const handleZoomIn = React.useCallback((): void => {
@@ -121,6 +154,20 @@ export function FamilyTree(): React.ReactNode {
                 size="sm"
               >
                 リセット
+              </PrimaryButton>
+
+              <PrimaryButton
+                onClick={handleExportSvg}
+                size="sm"
+              >
+                SVG
+              </PrimaryButton>
+
+              <PrimaryButton
+                onClick={handleExportPng}
+                size="sm"
+              >
+                PNG
               </PrimaryButton>
             </Flex>
           )
@@ -187,6 +234,7 @@ export function FamilyTree(): React.ReactNode {
               <Box flexShrink={0}>
                 <svg
                   height={result.layout.height * zoom}
+                  ref={svgRef}
                   viewBox={`0 0 ${result.layout.width.toString()} ${result.layout.height.toString()}`}
                   width={result.layout.width * zoom}
                 >

--- a/src/components/familyTree/exportImage.ts
+++ b/src/components/familyTree/exportImage.ts
@@ -1,0 +1,73 @@
+function cloneSvgForExport(
+  svgEl: SVGSVGElement,
+  width: number,
+  height: number,
+): SVGSVGElement {
+  const clone = svgEl.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute('width', width.toString());
+  clone.setAttribute('height', height.toString());
+  clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  return clone;
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function exportAsSvg(
+  svgEl: SVGSVGElement,
+  width: number,
+  height: number,
+  filename: string,
+): void {
+  const clone = cloneSvgForExport(svgEl, width, height);
+  const source = new XMLSerializer().serializeToString(clone);
+  const sourceWithHeader = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n${source}`;
+  const blob = new Blob([sourceWithHeader], { type: 'image/svg+xml;charset=utf-8' });
+  triggerDownload(blob, filename);
+}
+
+export async function exportAsPng(
+  svgEl: SVGSVGElement,
+  width: number,
+  height: number,
+  filename: string,
+  backgroundColor: string,
+): Promise<void> {
+  const clone = cloneSvgForExport(svgEl, width, height);
+  const source = new XMLSerializer().serializeToString(clone);
+  const svgBlob = new Blob([source], { type: 'image/svg+xml;charset=utf-8' });
+  const svgUrl = URL.createObjectURL(svgBlob);
+  try {
+    const img = new Image();
+    img.src = svgUrl;
+    await img.decode();
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (ctx === null) {
+      throw new Error('Canvas 2D コンテキストを取得できませんでした。');
+    }
+    ctx.fillStyle = backgroundColor;
+    ctx.fillRect(0, 0, width, height);
+    ctx.drawImage(img, 0, 0);
+    const pngBlob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((b) => {
+        if (b === null) {
+          reject(new Error('PNG への変換に失敗しました。'));
+          return;
+        }
+        resolve(b);
+      }, 'image/png');
+    });
+    triggerDownload(pngBlob, filename);
+  } finally {
+    URL.revokeObjectURL(svgUrl);
+  }
+}

--- a/src/components/familyTree/exportImage.ts
+++ b/src/components/familyTree/exportImage.ts
@@ -15,8 +15,12 @@ function triggerDownload(blob: Blob, filename: string): void {
   const link = document.createElement('a');
   link.href = url;
   link.download = filename;
+  document.body.appendChild(link);
   link.click();
-  URL.revokeObjectURL(url);
+  document.body.removeChild(link);
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 0);
 }
 
 export function exportAsSvg(


### PR DESCRIPTION
## Summary
- `exportImage.ts` に `exportAsSvg` / `exportAsPng` ヘルパを追加
  - SVG: `XMLSerializer` + `<?xml ?>` ヘッダで自己完結したファイルを出力
  - PNG: canvas に SVG を描画 → `toBlob` → ダウンロード。背景色 (`#ffffff`) を指定して透過を避ける
- `FamilyTree.tsx` のヘッダに「SVG」「PNG」ボタンを追加。ズーム倍率に関係なくレイアウトの native サイズで出力 (zoom=1 相当)
- PNG 生成失敗時はエラー toast

## Test plan
- [ ] `yarn dev` で起動 → `sample/family-tree.json` を読み込み
- [ ] 「SVG」で `family-tree.svg` がダウンロード、ブラウザで開いて全体が正しく見える
- [ ] 「PNG」で `family-tree.png` がダウンロード、画像ビューアで開いて全体が見える (背景白)
- [ ] ズームしてからエクスポートしても native サイズで出力される
- [ ] ライト/ダーク両モードで PNG の中身が読める

Closes #54