### PR TITLE
[#52] 家系図にミニマップを追加

### DIFF
--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -1,6 +1,7 @@
 import { exportAsPng, exportAsSvg } from '@/components/familyTree/exportImage';
 import { layoutFamilyTree } from '@/components/familyTree/layoutFamilyTree';
 import { MarriageEdge } from '@/components/familyTree/MarriageEdge';
+import { Minimap, type ScrollState } from '@/components/familyTree/Minimap';
 import { ParentChildEdge } from '@/components/familyTree/ParentChildEdge';
 import { PersonNode } from '@/components/familyTree/PersonNode';
 import { SecondaryParentEdge } from '@/components/familyTree/SecondaryParentEdge';
@@ -108,6 +109,48 @@ export function FamilyTree(): React.ReactNode {
   const showTree = result.ok && people.length > 0;
 
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const [scrollState, setScrollState] = React.useState<ScrollState>({
+    left: 0,
+    top: 0,
+    clientW: 0,
+    clientH: 0,
+  });
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (el === null) {
+      return undefined;
+    }
+    const update = (): void => {
+      setScrollState({
+        left: el.scrollLeft,
+        top: el.scrollTop,
+        clientW: el.clientWidth,
+        clientH: el.clientHeight,
+      });
+    };
+    update();
+    el.addEventListener('scroll', update);
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(el);
+    return () => {
+      el.removeEventListener('scroll', update);
+      resizeObserver.disconnect();
+    };
+  }, [showTree, zoom]);
+  const handleNavigate = React.useCallback((layoutX: number, layoutY: number): void => {
+    const el = containerRef.current;
+    if (el === null) {
+      return;
+    }
+    const LABELS_WIDTH = 64;
+    const targetLeft = (layoutX * zoom) + LABELS_WIDTH - (el.clientWidth / 2);
+    const targetTop = (layoutY * zoom) - (el.clientHeight / 2);
+    el.scrollTo({
+      left: Math.max(targetLeft, 0),
+      top: Math.max(targetTop, 0),
+      behavior: 'smooth',
+    });
+  }, [zoom]);
   const lastWheelTimeRef = React.useRef(0);
   React.useEffect(() => {
     const el = containerRef.current;
@@ -138,7 +181,10 @@ export function FamilyTree(): React.ReactNode {
   }, [showTree]);
 
   return (
-    <Flex direction="column">
+    <Flex
+      direction="column"
+      position="relative"
+    >
       <Flex
         alignItems="center"
         justifyContent="space-between"
@@ -307,6 +353,24 @@ export function FamilyTree(): React.ReactNode {
                 </svg>
               </Box>
             </Flex>
+          </Box>
+        )
+        : null}
+
+      {showTree
+        ? (
+          <Box
+            bottom={4}
+            position="absolute"
+            right={4}
+            zIndex={2}
+          >
+            <Minimap
+              layout={result.layout}
+              onNavigate={handleNavigate}
+              scrollState={scrollState}
+              zoom={zoom}
+            />
           </Box>
         )
         : null}

--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -1,7 +1,8 @@
 import { exportAsPng, exportAsSvg } from '@/components/familyTree/exportImage';
+import { LABELS_WIDTH } from '@/components/familyTree/layout/internalTypes';
 import { layoutFamilyTree } from '@/components/familyTree/layoutFamilyTree';
 import { MarriageEdge } from '@/components/familyTree/MarriageEdge';
-import { Minimap, type ScrollState } from '@/components/familyTree/Minimap';
+import { Minimap } from '@/components/familyTree/Minimap';
 import { ParentChildEdge } from '@/components/familyTree/ParentChildEdge';
 import { PersonNode } from '@/components/familyTree/PersonNode';
 import { SecondaryParentEdge } from '@/components/familyTree/SecondaryParentEdge';
@@ -109,48 +110,6 @@ export function FamilyTree(): React.ReactNode {
   const showTree = result.ok && people.length > 0;
 
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const [scrollState, setScrollState] = React.useState<ScrollState>({
-    left: 0,
-    top: 0,
-    clientW: 0,
-    clientH: 0,
-  });
-  React.useEffect(() => {
-    const el = containerRef.current;
-    if (el === null) {
-      return undefined;
-    }
-    const update = (): void => {
-      setScrollState({
-        left: el.scrollLeft,
-        top: el.scrollTop,
-        clientW: el.clientWidth,
-        clientH: el.clientHeight,
-      });
-    };
-    update();
-    el.addEventListener('scroll', update);
-    const resizeObserver = new ResizeObserver(update);
-    resizeObserver.observe(el);
-    return () => {
-      el.removeEventListener('scroll', update);
-      resizeObserver.disconnect();
-    };
-  }, [showTree, zoom]);
-  const handleNavigate = React.useCallback((layoutX: number, layoutY: number): void => {
-    const el = containerRef.current;
-    if (el === null) {
-      return;
-    }
-    const LABELS_WIDTH = 64;
-    const targetLeft = (layoutX * zoom) + LABELS_WIDTH - (el.clientWidth / 2);
-    const targetTop = (layoutY * zoom) - (el.clientHeight / 2);
-    el.scrollTo({
-      left: Math.max(targetLeft, 0),
-      top: Math.max(targetTop, 0),
-      behavior: 'smooth',
-    });
-  }, [zoom]);
   const lastWheelTimeRef = React.useRef(0);
   React.useEffect(() => {
     const el = containerRef.current;
@@ -283,7 +242,7 @@ export function FamilyTree(): React.ReactNode {
                 height={`${(result.layout.height * zoom).toString()}px`}
                 left={0}
                 position="sticky"
-                width="64px"
+                width={`${LABELS_WIDTH.toString()}px`}
                 zIndex={1}
               >
                 {result.layout.generationRows.map((row) => (
@@ -366,9 +325,8 @@ export function FamilyTree(): React.ReactNode {
             zIndex={2}
           >
             <Minimap
+              containerRef={containerRef}
               layout={result.layout}
-              onNavigate={handleNavigate}
-              scrollState={scrollState}
               zoom={zoom}
             />
           </Box>

--- a/src/components/familyTree/Minimap.tsx
+++ b/src/components/familyTree/Minimap.tsx
@@ -76,6 +76,13 @@ function computeViewport(
   };
 }
 
+function sameState(a: ScrollState, b: ScrollState): boolean {
+  return a.left === b.left
+    && a.top === b.top
+    && a.clientW === b.clientW
+    && a.clientH === b.clientH;
+}
+
 function useScrollState(containerRef: React.RefObject<HTMLDivElement | null>): ScrollState {
   const [scrollState, setScrollState] = React.useState<ScrollState>({
     left: 0,
@@ -88,12 +95,20 @@ function useScrollState(containerRef: React.RefObject<HTMLDivElement | null>): S
     if (el === null) {
       return undefined;
     }
+    let rafId: number | null = null;
     const update = (): void => {
-      setScrollState({
-        left: el.scrollLeft,
-        top: el.scrollTop,
-        clientW: el.clientWidth,
-        clientH: el.clientHeight,
+      if (rafId !== null) {
+        return;
+      }
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        const next: ScrollState = {
+          left: el.scrollLeft,
+          top: el.scrollTop,
+          clientW: el.clientWidth,
+          clientH: el.clientHeight,
+        };
+        setScrollState((prev) => (sameState(prev, next) ? prev : next));
       });
     };
     update();
@@ -101,6 +116,9 @@ function useScrollState(containerRef: React.RefObject<HTMLDivElement | null>): S
     const resizeObserver = new ResizeObserver(update);
     resizeObserver.observe(el);
     return () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
       el.removeEventListener('scroll', update);
       resizeObserver.disconnect();
     };
@@ -118,7 +136,8 @@ export function Minimap({ containerRef, layout, zoom }: Props): React.ReactNode 
     if (el === null) {
       return;
     }
-    const targetLeft = (layoutX * zoom) + LABELS_WIDTH - (el.clientWidth / 2);
+    const visibleTreeWidth = el.clientWidth - LABELS_WIDTH;
+    const targetLeft = (layoutX * zoom) - (visibleTreeWidth / 2);
     const targetTop = (layoutY * zoom) - (el.clientHeight / 2);
     el.scrollTo({
       left: Math.max(targetLeft, 0),
@@ -139,6 +158,18 @@ export function Minimap({ containerRef, layout, zoom }: Props): React.ReactNode 
     e.preventDefault();
     navigateTo(layout.width / 2, layout.height / 2);
   }, [layout.width, layout.height, navigateTo]);
+
+  const nodeRects = React.useMemo(() => layout.nodes.map((node) => (
+    <rect
+      fill={theme.nodeStroke}
+      height={node.height}
+      key={node.personId}
+      opacity={0.6}
+      width={node.width}
+      x={node.x}
+      y={node.y}
+    />
+  )), [layout.nodes, theme.nodeStroke]);
 
   if (dimensions.width === 0) {
     return null;
@@ -164,17 +195,7 @@ export function Minimap({ containerRef, layout, zoom }: Props): React.ReactNode 
         viewBox={`0 0 ${layout.width.toString()} ${layout.height.toString()}`}
         width={dimensions.width}
       >
-        {layout.nodes.map((node) => (
-          <rect
-            fill={theme.nodeStroke}
-            height={node.height}
-            key={node.personId}
-            opacity={0.6}
-            width={node.width}
-            x={node.x}
-            y={node.y}
-          />
-        ))}
+        {nodeRects}
 
         <rect
           fill="rgba(99, 102, 241, 0.15)"

--- a/src/components/familyTree/Minimap.tsx
+++ b/src/components/familyTree/Minimap.tsx
@@ -58,7 +58,7 @@ function computeViewport(
   zoom: number,
   layout: FamilyTreeLayout,
 ): ViewportRect {
-  const visibleLeft = Math.max((scrollState.left - LABELS_WIDTH) / zoom, 0);
+  const visibleLeft = Math.max(scrollState.left / zoom, 0);
   const visibleTop = Math.max(scrollState.top / zoom, 0);
   const visibleW = Math.min(
     (scrollState.clientW - LABELS_WIDTH) / zoom,

--- a/src/components/familyTree/Minimap.tsx
+++ b/src/components/familyTree/Minimap.tsx
@@ -1,3 +1,4 @@
+import { LABELS_WIDTH } from '@/components/familyTree/layout/internalTypes';
 import { type FamilyTreeLayout } from '@/components/familyTree/types';
 import { useFamilyTreeTheme } from '@/components/familyTree/useFamilyTreeTheme';
 import { Box } from '@chakra-ui/react';
@@ -5,9 +6,9 @@ import React from 'react';
 
 const MAX_MINIMAP_WIDTH = 240;
 const MAX_MINIMAP_HEIGHT = 160;
-const LABELS_WIDTH = 64;
+const VIEWPORT_STROKE_PX = 2;
 
-export interface ScrollState {
+interface ScrollState {
   left: number;
   top: number;
   clientW: number;
@@ -15,9 +16,8 @@ export interface ScrollState {
 }
 
 interface Props {
+  containerRef: React.RefObject<HTMLDivElement | null>;
   layout: FamilyTreeLayout;
-  onNavigate: (layoutX: number, layoutY: number) => void;
-  scrollState: ScrollState;
   zoom: number;
 }
 
@@ -76,25 +76,74 @@ function computeViewport(
   };
 }
 
-export function Minimap({
-  layout,
-  onNavigate,
-  scrollState,
-  zoom,
-}: Props): React.ReactNode {
+function useScrollState(containerRef: React.RefObject<HTMLDivElement | null>): ScrollState {
+  const [scrollState, setScrollState] = React.useState<ScrollState>({
+    left: 0,
+    top: 0,
+    clientW: 0,
+    clientH: 0,
+  });
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (el === null) {
+      return undefined;
+    }
+    const update = (): void => {
+      setScrollState({
+        left: el.scrollLeft,
+        top: el.scrollTop,
+        clientW: el.clientWidth,
+        clientH: el.clientHeight,
+      });
+    };
+    update();
+    el.addEventListener('scroll', update);
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(el);
+    return () => {
+      el.removeEventListener('scroll', update);
+      resizeObserver.disconnect();
+    };
+  }, [containerRef]);
+  return scrollState;
+}
+
+export function Minimap({ containerRef, layout, zoom }: Props): React.ReactNode {
   const theme = useFamilyTreeTheme();
   const dimensions = computeDimensions(layout);
+  const scrollState = useScrollState(containerRef);
   const viewport = computeViewport(scrollState, zoom, layout);
+  const navigateTo = React.useCallback((layoutX: number, layoutY: number): void => {
+    const el = containerRef.current;
+    if (el === null) {
+      return;
+    }
+    const targetLeft = (layoutX * zoom) + LABELS_WIDTH - (el.clientWidth / 2);
+    const targetTop = (layoutY * zoom) - (el.clientHeight / 2);
+    el.scrollTo({
+      left: Math.max(targetLeft, 0),
+      top: Math.max(targetTop, 0),
+      behavior: 'smooth',
+    });
+  }, [containerRef, zoom]);
   const handleClick = React.useCallback((e: React.MouseEvent<SVGSVGElement>): void => {
     const rect = e.currentTarget.getBoundingClientRect();
     const x = ((e.clientX - rect.left) / rect.width) * layout.width;
     const y = ((e.clientY - rect.top) / rect.height) * layout.height;
-    onNavigate(x, y);
-  }, [layout.width, layout.height, onNavigate]);
+    navigateTo(x, y);
+  }, [layout.width, layout.height, navigateTo]);
+  const handleKeyDown = React.useCallback((e: React.KeyboardEvent<SVGSVGElement>): void => {
+    if (e.key !== 'Enter' && e.key !== ' ') {
+      return;
+    }
+    e.preventDefault();
+    navigateTo(layout.width / 2, layout.height / 2);
+  }, [layout.width, layout.height, navigateTo]);
 
   if (dimensions.width === 0) {
     return null;
   }
+  const viewboxStroke = VIEWPORT_STROKE_PX * (layout.width / dimensions.width);
   return (
     <Box
       bg="bg"
@@ -105,9 +154,13 @@ export function Minimap({
       padding={1}
     >
       <svg
+        aria-label="家系図のミニマップ。クリックして該当位置にスクロールします。"
         height={dimensions.height}
         onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        role="button"
         style={{ cursor: 'pointer', display: 'block' }}
+        tabIndex={0}
         viewBox={`0 0 ${layout.width.toString()} ${layout.height.toString()}`}
         width={dimensions.width}
       >
@@ -128,7 +181,7 @@ export function Minimap({
           height={viewport.height}
           pointerEvents="none"
           stroke="#6366f1"
-          strokeWidth={Math.max(layout.width / dimensions.width, 2)}
+          strokeWidth={viewboxStroke}
           width={viewport.width}
           x={viewport.x}
           y={viewport.y}

--- a/src/components/familyTree/Minimap.tsx
+++ b/src/components/familyTree/Minimap.tsx
@@ -1,0 +1,139 @@
+import { type FamilyTreeLayout } from '@/components/familyTree/types';
+import { useFamilyTreeTheme } from '@/components/familyTree/useFamilyTreeTheme';
+import { Box } from '@chakra-ui/react';
+import React from 'react';
+
+const MAX_MINIMAP_WIDTH = 240;
+const MAX_MINIMAP_HEIGHT = 160;
+const LABELS_WIDTH = 64;
+
+export interface ScrollState {
+  left: number;
+  top: number;
+  clientW: number;
+  clientH: number;
+}
+
+interface Props {
+  layout: FamilyTreeLayout;
+  onNavigate: (layoutX: number, layoutY: number) => void;
+  scrollState: ScrollState;
+  zoom: number;
+}
+
+interface Dimensions {
+  width: number;
+  height: number;
+}
+
+function computeDimensions(layout: FamilyTreeLayout): Dimensions {
+  if (layout.width === 0 || layout.height === 0) {
+    return {
+      width: 0,
+      height: 0,
+    };
+  }
+  const aspectRatio = layout.width / layout.height;
+  let width = MAX_MINIMAP_WIDTH;
+  let height = width / aspectRatio;
+  if (height > MAX_MINIMAP_HEIGHT) {
+    height = MAX_MINIMAP_HEIGHT;
+    width = height * aspectRatio;
+  }
+  return {
+    width,
+    height,
+  };
+}
+
+interface ViewportRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function computeViewport(
+  scrollState: ScrollState,
+  zoom: number,
+  layout: FamilyTreeLayout,
+): ViewportRect {
+  const visibleLeft = Math.max((scrollState.left - LABELS_WIDTH) / zoom, 0);
+  const visibleTop = Math.max(scrollState.top / zoom, 0);
+  const visibleW = Math.min(
+    (scrollState.clientW - LABELS_WIDTH) / zoom,
+    layout.width - visibleLeft,
+  );
+  const visibleH = Math.min(
+    scrollState.clientH / zoom,
+    layout.height - visibleTop,
+  );
+  return {
+    x: visibleLeft,
+    y: visibleTop,
+    width: Math.max(visibleW, 0),
+    height: Math.max(visibleH, 0),
+  };
+}
+
+export function Minimap({
+  layout,
+  onNavigate,
+  scrollState,
+  zoom,
+}: Props): React.ReactNode {
+  const theme = useFamilyTreeTheme();
+  const dimensions = computeDimensions(layout);
+  const viewport = computeViewport(scrollState, zoom, layout);
+  const handleClick = React.useCallback((e: React.MouseEvent<SVGSVGElement>): void => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) / rect.width) * layout.width;
+    const y = ((e.clientY - rect.top) / rect.height) * layout.height;
+    onNavigate(x, y);
+  }, [layout.width, layout.height, onNavigate]);
+
+  if (dimensions.width === 0) {
+    return null;
+  }
+  return (
+    <Box
+      bg="bg"
+      borderColor="border"
+      borderRadius="md"
+      borderWidth="1px"
+      boxShadow="md"
+      padding={1}
+    >
+      <svg
+        height={dimensions.height}
+        onClick={handleClick}
+        style={{ cursor: 'pointer', display: 'block' }}
+        viewBox={`0 0 ${layout.width.toString()} ${layout.height.toString()}`}
+        width={dimensions.width}
+      >
+        {layout.nodes.map((node) => (
+          <rect
+            fill={theme.nodeStroke}
+            height={node.height}
+            key={node.personId}
+            opacity={0.6}
+            width={node.width}
+            x={node.x}
+            y={node.y}
+          />
+        ))}
+
+        <rect
+          fill="rgba(99, 102, 241, 0.15)"
+          height={viewport.height}
+          pointerEvents="none"
+          stroke="#6366f1"
+          strokeWidth={Math.max(layout.width / dimensions.width, 2)}
+          width={viewport.width}
+          x={viewport.x}
+          y={viewport.y}
+        />
+      </svg>
+    </Box>
+  );
+}

--- a/src/components/familyTree/layout/internalTypes.ts
+++ b/src/components/familyTree/layout/internalTypes.ts
@@ -12,6 +12,7 @@ export const GENERATION_GAP = 80;
 export const UNIT_GAP = 32;
 export const COUPLE_GAP = 16;
 export const PADDING = 24;
+export const LABELS_WIDTH = 64;
 
 export type UnitType = 'couple' | 'single';
 


### PR DESCRIPTION
## Summary
- `Minimap.tsx` を追加。家系図全体を縮小表示 (最大 240×160、アスペクト比保持)
  - ノードはグレーの矩形のみで簡略化
  - ビューポート矩形 (青) を重ねて現在位置を可視化
  - クリックで該当位置に smooth scroll
- `FamilyTree` にスクロール位置 (`scrollState`) を追跡。`scroll` イベント + `ResizeObserver` で更新
- 外側 Flex を `position: relative` にし、ミニマップを右下に absolute 配置

## Test plan
- [ ] `yarn dev` で起動 → `sample/family-tree.json` を読み込み
- [ ] 右下にミニマップが表示される
- [ ] スクロール / ズームすると viewport 矩形が連動
- [ ] ミニマップをクリック → 該当位置に smooth scroll
- [ ] データなし時はミニマップが表示されない
- [ ] ライト/ダーク両モードで識別可能

## 既知の今後
- ドラッグでの連続スクロール
- 折りたたみ/非表示の切り替え

Closes #52