### PR TITLE
[#67] 家系図エリアの高さを 70vh 固定に

### DIFF
--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -230,7 +230,7 @@ export function FamilyTree(): React.ReactNode {
       {showTree
         ? (
           <Box
-            maxHeight="70vh"
+            height="70vh"
             overflowX="auto"
             overflowY="auto"
             ref={containerRef}


### PR DESCRIPTION
## Summary
- 家系図エリアの `maxHeight: 70vh` を `height: 70vh` に変更
- ズーム倍率を下げてもエリアの高さが縮まず一定になる
- コンテンツが小さい時は枠内に余白、大きい時は枠内スクロール

## Test plan
- [ ] `yarn dev` で起動
- [ ] `sample/family-tree.json` をインポート
- [ ] ズームを 25%〜400% で切り替えても家系図エリアの高さが変わらない
- [ ] 倍率が低いときは枠内に余白がある
- [ ] 倍率が高いときは枠内で縦/横スクロールできる

Closes #67