### PR TITLE
[#79] main の lint エラーを修正する

### DIFF
--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -1,4 +1,5 @@
 import { exportAsPng, exportAsSvg } from '@/components/familyTree/exportImage';
+import { FamilyTreeToolbar } from '@/components/familyTree/FamilyTreeToolbar';
 import { LABELS_WIDTH } from '@/components/familyTree/layout/internalTypes';
 import { layoutFamilyTree } from '@/components/familyTree/layoutFamilyTree';
 import { MarriageEdge } from '@/components/familyTree/MarriageEdge';
@@ -6,9 +7,9 @@ import { Minimap } from '@/components/familyTree/Minimap';
 import { ParentChildEdge } from '@/components/familyTree/ParentChildEdge';
 import { PersonNode } from '@/components/familyTree/PersonNode';
 import { SecondaryParentEdge } from '@/components/familyTree/SecondaryParentEdge';
+import { useWheelZoom } from '@/components/familyTree/useWheelZoom';
 import { PersonDialog } from '@/components/person/PersonDialog';
 import { H2 } from '@/components/ui/H2';
-import { PrimaryButton } from '@/components/ui/PrimaryButton';
 import { toaster } from '@/components/ui/toaster';
 import { type Person } from '@/schemas/personSchema';
 import { usePeopleStore } from '@/store/personStore';
@@ -110,34 +111,12 @@ export function FamilyTree(): React.ReactNode {
   const showTree = result.ok && people.length > 0;
 
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const lastWheelTimeRef = React.useRef(0);
-  React.useEffect(() => {
-    const el = containerRef.current;
-    if (el === null) {
-      return undefined;
-    }
-    const WHEEL_COOLDOWN_MS = 80;
-    const handleWheel = (e: WheelEvent): void => {
-      if (!e.ctrlKey && !e.metaKey) {
-        return;
-      }
-      e.preventDefault();
-      const now = performance.now();
-      if (now - lastWheelTimeRef.current < WHEEL_COOLDOWN_MS) {
-        return;
-      }
-      lastWheelTimeRef.current = now;
-      if (e.deltaY < 0) {
-        setZoomIndex((i) => Math.min(i + 1, ZOOM_LEVELS.length - 1));
-      } else if (e.deltaY > 0) {
-        setZoomIndex((i) => Math.max(i - 1, 0));
-      }
-    };
-    el.addEventListener('wheel', handleWheel, { passive: false });
-    return () => {
-      el.removeEventListener('wheel', handleWheel);
-    };
-  }, [showTree]);
+  useWheelZoom({
+    containerRef,
+    enabled: showTree,
+    onZoomIn: handleZoomIn,
+    onZoomOut: handleZoomOut,
+  });
 
   return (
     <Flex
@@ -154,57 +133,14 @@ export function FamilyTree(): React.ReactNode {
 
         {showTree
           ? (
-            <Flex
-              alignItems="center"
-              gap={2}
-            >
-              <PrimaryButton
-                aria-label="ズームアウト"
-                onClick={handleZoomOut}
-                size="sm"
-                title="ズームアウト"
-              >
-                −
-              </PrimaryButton>
-
-              <Text
-                fontSize="sm"
-                minWidth="50px"
-                textAlign="center"
-              >
-                {`${zoomPercent.toString()}%`}
-              </Text>
-
-              <PrimaryButton
-                aria-label="ズームイン"
-                onClick={handleZoomIn}
-                size="sm"
-                title="ズームイン"
-              >
-                +
-              </PrimaryButton>
-
-              <PrimaryButton
-                onClick={handleZoomReset}
-                size="sm"
-              >
-                リセット
-              </PrimaryButton>
-
-              <PrimaryButton
-                onClick={handleExportSvg}
-                size="sm"
-              >
-                SVG
-              </PrimaryButton>
-
-              <PrimaryButton
-                onClick={handleExportPng}
-                size="sm"
-              >
-                PNG
-              </PrimaryButton>
-            </Flex>
+            <FamilyTreeToolbar
+              onExportPng={handleExportPng}
+              onExportSvg={handleExportSvg}
+              onZoomIn={handleZoomIn}
+              onZoomOut={handleZoomOut}
+              onZoomReset={handleZoomReset}
+              zoomPercent={zoomPercent}
+            />
           )
           : null}
       </Flex>

--- a/src/components/familyTree/FamilyTreeToolbar.tsx
+++ b/src/components/familyTree/FamilyTreeToolbar.tsx
@@ -1,0 +1,75 @@
+import { PrimaryButton } from '@/components/ui/PrimaryButton';
+import { Flex, Text } from '@chakra-ui/react';
+import React from 'react';
+
+interface Props {
+  onExportPng: () => void;
+  onExportSvg: () => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onZoomReset: () => void;
+  zoomPercent: number;
+}
+
+export function FamilyTreeToolbar({
+  onExportPng,
+  onExportSvg,
+  onZoomIn,
+  onZoomOut,
+  onZoomReset,
+  zoomPercent,
+}: Props): React.ReactNode {
+  return (
+    <Flex
+      alignItems="center"
+      gap={2}
+    >
+      <PrimaryButton
+        aria-label="ズームアウト"
+        onClick={onZoomOut}
+        size="sm"
+        title="ズームアウト"
+      >
+        −
+      </PrimaryButton>
+
+      <Text
+        fontSize="sm"
+        minWidth="50px"
+        textAlign="center"
+      >
+        {`${zoomPercent.toString()}%`}
+      </Text>
+
+      <PrimaryButton
+        aria-label="ズームイン"
+        onClick={onZoomIn}
+        size="sm"
+        title="ズームイン"
+      >
+        +
+      </PrimaryButton>
+
+      <PrimaryButton
+        onClick={onZoomReset}
+        size="sm"
+      >
+        リセット
+      </PrimaryButton>
+
+      <PrimaryButton
+        onClick={onExportSvg}
+        size="sm"
+      >
+        SVG
+      </PrimaryButton>
+
+      <PrimaryButton
+        onClick={onExportPng}
+        size="sm"
+      >
+        PNG
+      </PrimaryButton>
+    </Flex>
+  );
+}

--- a/src/components/familyTree/Minimap.tsx
+++ b/src/components/familyTree/Minimap.tsx
@@ -108,14 +108,16 @@ function useScrollState(containerRef: React.RefObject<HTMLDivElement | null>): S
           clientW: el.clientWidth,
           clientH: el.clientHeight,
         };
-        setScrollState((prev) => (sameState(prev, next) ? prev : next));
+        setScrollState((prev) => {
+          return sameState(prev, next) ? prev : next;
+        });
       });
     };
     update();
     el.addEventListener('scroll', update);
     const resizeObserver = new ResizeObserver(update);
     resizeObserver.observe(el);
-    return () => {
+    return (): void => {
       if (rafId !== null) {
         cancelAnimationFrame(rafId);
       }
@@ -190,7 +192,10 @@ export function Minimap({ containerRef, layout, zoom }: Props): React.ReactNode 
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         role="button"
-        style={{ cursor: 'pointer', display: 'block' }}
+        style={{
+          cursor: 'pointer',
+          display: 'block',
+        }}
         tabIndex={0}
         viewBox={`0 0 ${layout.width.toString()} ${layout.height.toString()}`}
         width={dimensions.width}

--- a/src/components/familyTree/useWheelZoom.ts
+++ b/src/components/familyTree/useWheelZoom.ts
@@ -1,0 +1,45 @@
+import React from 'react';
+
+const WHEEL_COOLDOWN_MS = 80;
+
+interface Options {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  enabled: boolean;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+}
+
+export function useWheelZoom({
+  containerRef,
+  enabled,
+  onZoomIn,
+  onZoomOut,
+}: Options): void {
+  const lastTimeRef = React.useRef(0);
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (!enabled || el === null) {
+      return undefined;
+    }
+    const handleWheel = (e: WheelEvent): void => {
+      if (!e.ctrlKey && !e.metaKey) {
+        return;
+      }
+      e.preventDefault();
+      const now = performance.now();
+      if (now - lastTimeRef.current < WHEEL_COOLDOWN_MS) {
+        return;
+      }
+      lastTimeRef.current = now;
+      if (e.deltaY < 0) {
+        onZoomIn();
+      } else if (e.deltaY > 0) {
+        onZoomOut();
+      }
+    };
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return (): void => {
+      el.removeEventListener('wheel', handleWheel);
+    };
+  }, [containerRef, enabled, onZoomIn, onZoomOut]);
+}


### PR DESCRIPTION
## Summary
- ズーム + エクスポートのツールバーを `FamilyTreeToolbar` に抽出
- マウスホイールズームの `useEffect` を `useWheelZoom` フックに抽出
- `FamilyTree.tsx` を 348 → 284 行に縮減 (max-lines: 300 解消)
- 各種 lint 違反を修正:
  - useEffect cleanup 関数の戻り値型を明示
  - `no-confusing-arrow` 対策で三項を block return に
  - svg の style プロパティを別行に分割

## Test plan
- [ ] `yarn lint` で `FamilyTree.tsx` / `Minimap.tsx` のエラーがゼロ
- [ ] `yarn tsc` 通過
- [ ] `yarn test` で 4 件 pass
- [ ] ブラウザでツールバー (−/+/リセット/SVG/PNG)、Ctrl + ホイールズーム、ミニマップが従来通り動作

## 残り
`PersonDialog` / `AddRelationDialog` の `@typescript-eslint/no-misused-promises` はこの issue の範囲外 (本文に明記済み)。別途必要なら issue 化する。

Closes #79
