### PR TITLE
[#84] Dialog の onSubmit の no-misused-promises を解消

### DIFF
--- a/src/components/person/PersonDialog.tsx
+++ b/src/components/person/PersonDialog.tsx
@@ -91,7 +91,11 @@ export function PersonDialog({ isOpen, onOpenChange, person }: PersonDialogProps
               {isEdit ? '人物編集' : '人物追加'}
             </Dialog.Header>
 
-            <form onSubmit={handleSubmit(onSubmit)}>
+            <form
+              onSubmit={(e): void => {
+                void handleSubmit(onSubmit)(e);
+              }}
+            >
               <Dialog.Body>
                 <Flex
                   direction="column"

--- a/src/components/relation/AddRelationDialog.tsx
+++ b/src/components/relation/AddRelationDialog.tsx
@@ -69,7 +69,11 @@ export function AddRelationDialog({ isOpen, onOpenChange }: AddRelationDialogPro
               関係追加
             </Dialog.Header>
 
-            <form onSubmit={handleSubmit(onSubmit)}>
+            <form
+              onSubmit={(e): void => {
+                void handleSubmit(onSubmit)(e);
+              }}
+            >
               <Dialog.Body>
                 <Flex direction="column">
                   <Field.Root invalid={Boolean(errors.relationType)}>


### PR DESCRIPTION
## Summary
- `PersonDialog` / `AddRelationDialog` の `<form onSubmit={handleSubmit(onSubmit)}>` を Promise 戻り値を捨てるラッパに置き換え
- これで `yarn lint` がエラーゼロになり、CI (#70) を入れたとき初回から green を維持できる

## Test plan
- [ ] `yarn lint` でエラーゼロ (warning のみ残る)
- [ ] `yarn tsc -p tsconfig.app.json --noEmit` 通過
- [ ] `yarn test` で 4 件 pass
- [ ] ブラウザで人物追加 / 人物編集 / 削除 / 関係追加が動作する

Closes #84