### PR TITLE
[#70] CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .node-version
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Audit dependencies
+        run: yarn npm audit --severity high --all
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Type check
+        run: yarn tsc -p tsconfig.app.json --noEmit
+
+      - name: Test
+        run: yarn test
+
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` を追加
- トリガ: `pull_request` と `push` (main)
- ステップ: install → audit → lint → tsc → test → build
- セキュリティ対策:
  - `permissions: contents: read` で最小権限
  - Actions を SHA pin (`actions/checkout@11bd719...` `actions/setup-node@49933ea...`)
  - `concurrency` で同一 ref の重複ジョブをキャンセル
- `yarn npm audit --severity high --all` を含めることで #77 のサプライチェーン対策に寄与

## Test plan
- [ ] PR を上げると CI が走る
- [ ] 全ステップ green
- [ ] 同じ PR に再 push したとき、前のジョブがキャンセルされる

## 関連
- #77 (サプライチェーン対策ベースライン)
- #76 (PR の lint は別 workflow)
- #79 / #84 (lint エラー解消 — 完了済)

Closes #70