### PR TITLE
[#72] Issue テンプレートを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,30 @@
+name: バグ報告
+description: 動作の不具合・想定外の挙動を報告する
+labels:
+  - bug
+body:
+  - type: textarea
+    id: phenomenon
+    attributes:
+      label: 現象
+      description: 何が起きたかを簡潔に
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 手順を箇条書きで
+      value: |
+        1.
+        2.
+        3.
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する挙動
+  - type: textarea
+    id: environment
+    attributes:
+      label: 環境
+      description: ブラウザ / OS / Node バージョン 等

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/design-discussion.yml
+++ b/.github/ISSUE_TEMPLATE/design-discussion.yml
@@ -1,0 +1,37 @@
+name: 設計議論
+description: 実装方針が複数あり、設計判断が必要な議題を立ち上げる
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景
+      description: 議論したい問題・課題の概要
+    validations:
+      required: true
+  - type: textarea
+    id: options
+    attributes:
+      label: 選択肢
+      description: 検討中のアプローチを A / B / C の形で列挙し、それぞれの pros / cons を整理する
+      value: |
+        ### A.
+        - Pros:
+        - Cons:
+
+        ### B.
+        - Pros:
+        - Cons:
+    validations:
+      required: true
+  - type: textarea
+    id: axes
+    attributes:
+      label: 比較軸
+      description: 何を基準に意思決定するか (コスト / メンテ性 / UX / 互換性 等)
+  - type: textarea
+    id: related
+    attributes:
+      label: 関連
+      description: 関連 issue / PR / ドキュメント 等

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,29 @@
+name: 機能追加・改善
+description: 新機能や既存機能の改善を提案する
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景
+      description: なぜこの機能が必要か、現状の課題
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する挙動
+      description: どう動くと良いか
+    validations:
+      required: true
+  - type: textarea
+    id: considerations
+    attributes:
+      label: 検討事項
+      description: 実装案 / 影響範囲 / 既知のトレードオフ など
+  - type: textarea
+    id: related
+    attributes:
+      label: 関連
+      description: 関連する issue / PR / ドキュメント 等


### PR DESCRIPTION
## Summary

- `.github/ISSUE_TEMPLATE/` 配下に 3 種類のテンプレを追加 (Issue Forms 形式)
  - `bug.yml`: 現象 / 再現手順 / 期待 / 環境
  - `enhancement.yml`: 背景 / 期待する挙動 / 検討事項 / 関連
  - `design-discussion.yml`: 背景 / 選択肢 (A/B…) / 比較軸 / 関連
- `config.yml` で `blank_issues_enabled: false` を設定し、テンプレ選択を強制

## Test plan

- [ ] このPR後、リポジトリの Issues > New Issue で 3 種類のテンプレが選択肢に表示される
- [ ] 各テンプレで必須項目 (`required: true`) を埋めないと submit できない
- [ ] 「テンプレ無し」の選択肢が表示されない

Closes #72
