### PR TITLE
[#74] Dependabot による依存自動更新を有効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - patch
+          - minor
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` を追加
  - `npm`: 週次。patch/minor を `production` / `development` 別にグルーピング (major は個別 PR)
  - `github-actions`: 週次。すべて 1 グループにまとめる (SHA pin の自動更新)
  - `open-pull-requests-limit: 10`
- 自動 merge は無効 (default)。レビュー負荷の集約と #77 のサプライチェーン規約に従う

## Test plan

- [ ] マージ後、Insights > Dependency graph > Dependabot 画面でルールが認識される
- [ ] 1 週間以内に最初の自動 PR が出る (実装時にはここをチェックリストとして残し、別途確認)

Closes #74
