### PR TITLE
[#106] Dependabot を 2 グループに集約して PR 数を抑える

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
-      production-minor-patch:
+      production:
         dependency-type: production
-        update-types:
-          - patch
-          - minor
-      development-minor-patch:
+      development:
         dependency-type: development
-        update-types:
-          - patch
-          - minor
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` のグループ設定を見直し、major も含めて `production` / `development` の 2 グループに集約
- `open-pull-requests-limit` を 10 → 5 に下げて物量を抑制

## Test plan

- [ ] マージ後、現状の個別 dependabot PR (uuid 14.0.0 / zod 4.4.3 / stylistic 5.10.0 等) は手動で close する
- [ ] 次回 Dependabot run で `production` / `development` のグループ PR が生成される

Closes #106
