### PR TITLE
[#124] Dependabot に cooldown 設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # publish 直後の悪意あるバージョンを取り込まないよう、
+    # .yarnrc.yml の npmMinimalAgeGate と二重で防御層を作る。
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
     groups:
       production:
         dependency-type: production
@@ -15,6 +22,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
     groups:
       actions:
         patterns:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@
   - **既知の副作用**: macOS で Vite/chokidar が依存する `fsevents` のネイティブ binary がビルドされず、`yarn dev` のファイル監視が polling にフォールバックして性能劣化する。問題が出たら上記の手順で回避
 - **新規パブリッシュの即時 install を防ぐ**: `.yarnrc.yml` の `npmMinimalAgeGate: 4320` (分 = 3 日) によって、3 日未満の新規 publish は install されない。即時に削除される悪意のあるパッケージから守る
   - **例外運用**: 緊急のセキュリティ修正で 3 日未満のバージョンを入れたい場合は、`yarn config set npmMinimalAgeGate <小さい値>` で一時的に下げて install し、終わったら元に戻す (.yarnrc.yml への commit 戻しを忘れずに)
+  - **Dependabot 側にも `cooldown` 設定**: `.github/dependabot.yml` で publish からの待機日数を指定し、PR 作成時点でも同様に遅延させている (二重防御)
 - **`yarn.lock` の diff レビュー**: PR で `yarn.lock` の変更を必ず目視確認 (予期せぬ大量更新は怪しい)
 - **GitHub Actions は SHA pin**: `uses: org/action@<40桁の commit SHA>` で固定し、`@v4` のような可変タグは避ける (タグは後から移動できる)
 - **第三者製 Actions は最小限**: 公式 (`actions/*`) を優先


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` の npm / github-actions ecosystem に `cooldown` を追加
- `default-days: 3 / major: 7 / minor: 3 / patch: 1` で publish 直後のバージョンを取り込まない
- `.yarnrc.yml` の `npmMinimalAgeGate` (install 時防御) と Dependabot 側 (PR 作成時防御) で二重に守る
- CLAUDE.md のサプライチェーン対策セクションに併用方針を追記

## Test plan
- [x] YAML フォーマット確認
- [ ] 次回 Dependabot 実行で PR が cooldown を考慮することを観察 (publish 直後のバージョンが PR されない)

Closes #124