### PR TITLE
[#126] Dependabot grouping を update-types で分割

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,26 @@ updates:
       semver-major-days: 7
       semver-minor-days: 3
       semver-patch-days: 1
+    # major は影響が大きいのでグループから分離し、個別レビューできるようにする。
     groups:
       production:
         dependency-type: production
+        update-types:
+          - minor
+          - patch
+      production-major:
+        dependency-type: production
+        update-types:
+          - major
       development:
         dependency-type: development
+        update-types:
+          - minor
+          - patch
+      development-major:
+        dependency-type: development
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: /
@@ -31,3 +46,11 @@ updates:
       actions:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - major


### PR DESCRIPTION
## Summary
- production / development / actions の各 group を `minor + patch` と `major` の 2 つに分割
- CLAUDE.md の方針 (major / minor / patch を分けて diff レビュー) と運用を整合させる
- 副次効果: zod 4 のような major bump が他の minor/patch 更新と束ねられず、個別 PR で対応できる (#122 で発覚した問題への構造的対処)

## Test plan
- [x] YAML フォーマット確認
- [ ] マージ後、次の Dependabot 実行で major bump と minor/patch bump が別 PR に分離されること
- [ ] #122 を close → Dependabot による再生成を確認

Closes #126