### PR TITLE
[#127] zod 3 → 4 へ移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.5.0",
     "uuid": "^14.0.0",
-    "zod": "^3.24.2",
+    "zod": "^4",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/src/schemas/personSchema.ts
+++ b/src/schemas/personSchema.ts
@@ -29,7 +29,7 @@ export const sexList = [
 ];
 
 export const personSchema = z.object({
-  id: z.string().uuid()
+  id: z.uuid()
     .describe('ID'),
   familyName: z.string().min(1)
     .describe('姓'),
@@ -42,12 +42,12 @@ export const personSchema = z.object({
   sex: z.enum(Object.values(Sex) as [string, ...string[]])
     .describe('性別'),
   birth: z.union([
-    z.string().date(),
+    z.iso.date(),
     z.literal(''),
   ])
     .describe('生年月日'),
   death: z.union([
-    z.string().date(),
+    z.iso.date(),
     z.literal(''),
   ])
     .describe('没年月日'),

--- a/src/schemas/relationSchema.ts
+++ b/src/schemas/relationSchema.ts
@@ -37,7 +37,7 @@ export const relationTypeList = [
 ];
 
 export const relationSchema = z.object({
-  id: z.string().uuid()
+  id: z.uuid()
     .describe('ID'),
   relationType: z.array(
     z.enum(Object.values(RelationType) as [string, ...string[]]),
@@ -45,11 +45,11 @@ export const relationSchema = z.object({
     .describe('関係タイプ'),
   persons: z.object({
     personId1: z.array(
-      z.string().uuid(),
+      z.uuid(),
     ).max(1)
       .describe('人物1'),
     personId2: z.array(
-      z.string().uuid(),
+      z.uuid(),
     ).max(1)
       .describe('人物2'),
   }).refine((val) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,7 +3574,7 @@ __metadata:
     uuid: "npm:^14.0.0"
     vite: "npm:^8.0.13"
     vitest: "npm:^4.1.7"
-    zod: "npm:^3.24.2"
+    zod: "npm:^4"
     zustand: "npm:^5.0.3"
   languageName: unknown
   linkType: soft
@@ -6376,14 +6376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.24.2":
-  version: 3.24.2
-  resolution: "zod@npm:3.24.2"
-  checksum: 10c0/c638c7220150847f13ad90635b3e7d0321b36cce36f3fc6050ed960689594c949c326dfe2c6fa87c14b126ee5d370ccdebd6efb304f41ef5557a4aaca2824565
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.25.0 || ^4.0.0":
+"zod@npm:^3.25.0 || ^4.0.0, zod@npm:^4":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3


### PR DESCRIPTION
## Summary
- `zod` を 4.x に bump
- 非推奨 API を新 API に置換 (`z.string().uuid()` → `z.uuid()`、`z.string().date()` → `z.iso.date()`)
- 影響範囲は `src/schemas/{personSchema,relationSchema}.ts` のみ

## 互換性メモ
zod 4 の `z.uuid()` は v1〜v8 の UUID 形式 (バージョン桁が 1〜8、variant 桁が 8/9/a/b) を要求する。`uuid` パッケージの v4 生成と `sample/family-tree.json` の既存 ID (`...-4xxx-8xxx-...`) はいずれも v4 形式なので互換性は維持。

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] `yarn test` (4/4)
- [x] `yarn build`
- [x] `node` で `z.uuid()` / `z.iso.date()` の挙動確認
- [ ] **ブラウザでサンプル JSON のインポート確認** (D&D / ファイル選択両方)
- [ ] PersonDialog / AddRelationDialog の送信時バリデーションが動くこと

Closes #127