### PR TITLE
[#81] レイアウトロジックのテストカバレッジ拡充

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@
 - `@typescript-eslint/restrict-template-expressions`: 数値は `.toString()` で文字列化
 - `@typescript-eslint/strict-boolean-expressions`: `if (str)` 不可、`str !== ''` 等で明示
 - `@typescript-eslint/no-unnecessary-condition`: 型上 undefined にならないチェックは無効。`noUncheckedIndexedAccess` が off なので `arr[0]` は `T` 型 → 配列の length チェックで防御する
-- `max-lines-per-function: 50` は `.ts` のみ (`.tsx` は対象外)。長い関数は小さなヘルパに分割
+- `max-lines-per-function: 50` は `.ts` のみ (`.tsx` とテストファイル `.test.ts` は対象外)。長い関数は小さなヘルパに分割
 
 ### CSS / レイアウト
 - `<input type="file">` の change イベントは同じファイルを再選択しても発火しない。click 前に `inputRef.current.value = ''` でリセットする

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -75,9 +75,10 @@ export default tseslint.config(
     },
   },
   {
-    files: ['src/**/*.{ts}'],
+    files: ['src/**/*.ts'],
+    ignores: ['src/**/*.test.ts'],
     rules: {
-      // 1つの関数の行数を50以下に制限
+      // 1つの関数の行数を50以下に制限 (.tsx とテストファイルは対象外)
       'max-lines-per-function': ['error', { max: 50 }],
     },
   },

--- a/src/components/familyTree/layout/buildUnits.test.ts
+++ b/src/components/familyTree/layout/buildUnits.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildChildToParents,
+  buildCoupleUnits,
+  buildSingleUnits,
+} from '@/components/familyTree/layout/buildUnits';
+import { type Person, Sex } from '@/schemas/personSchema';
+import { type Relation, RelationType } from '@/schemas/relationSchema';
+
+const ID = {
+  PARENT: '11111111-1111-4111-8111-111111111111',
+  CHILD: '22222222-2222-4222-8222-222222222222',
+  HUSBAND: '33333333-3333-4333-8333-333333333333',
+  WIFE: '44444444-4444-4444-8444-444444444444',
+  SOLO: '55555555-5555-4555-8555-555555555555',
+  REL_MARRIED: 'aaaaaaaa-0000-4000-8000-000000000001',
+  REL_COUPLE: 'aaaaaaaa-0000-4000-8000-000000000002',
+  REL_PARENT: 'bbbbbbbb-0000-4000-8000-000000000001',
+  REL_ADOPTED: 'bbbbbbbb-0000-4000-8000-000000000002',
+} as const;
+
+function makePerson(id: string): Person {
+  return {
+    id,
+    familyName: '姓',
+    givenName: '名',
+    familyNameKana: 'カナ',
+    givenNameKana: 'カナ',
+    sex: Sex.UNKNOWN,
+    birth: '',
+    death: '',
+  };
+}
+
+function makeRelation(
+  id: string,
+  type: RelationType,
+  p1: string,
+  p2: string,
+): Relation {
+  return {
+    id,
+    relationType: [type],
+    persons: {
+      personId1: [p1],
+      personId2: [p2],
+    },
+  };
+}
+
+describe('buildCoupleUnits', () => {
+  it('夫婦関係から couple ユニットを作る', () => {
+    const rel = makeRelation(
+      ID.REL_MARRIED,
+      RelationType.MARRIED_COUPLE,
+      ID.HUSBAND,
+      ID.WIFE,
+    );
+    const unitOfPerson = new Map<string, string>();
+    const units = buildCoupleUnits([rel], unitOfPerson);
+    expect(units).toHaveLength(1);
+    expect(units[0].type).toBe('couple');
+    expect(units[0].personIds).toEqual([ID.HUSBAND, ID.WIFE]);
+    expect(units[0].marriageType).toBe('married');
+    expect(unitOfPerson.get(ID.HUSBAND)).toBe(units[0].id);
+    expect(unitOfPerson.get(ID.WIFE)).toBe(units[0].id);
+  });
+
+  it('事実婚は marriageType=couple になる', () => {
+    const rel = makeRelation(
+      ID.REL_COUPLE,
+      RelationType.COUPLE,
+      ID.HUSBAND,
+      ID.WIFE,
+    );
+    const units = buildCoupleUnits([rel], new Map());
+    expect(units[0].marriageType).toBe('couple');
+  });
+
+  it('親子関係は無視する', () => {
+    const rel = makeRelation(
+      ID.REL_PARENT,
+      RelationType.PARENT_CHILD,
+      ID.PARENT,
+      ID.CHILD,
+    );
+    const units = buildCoupleUnits([rel], new Map());
+    expect(units).toHaveLength(0);
+  });
+
+  it('既にユニット化された人物を含む夫婦関係はスキップする', () => {
+    const rel1 = makeRelation(
+      ID.REL_MARRIED,
+      RelationType.MARRIED_COUPLE,
+      ID.HUSBAND,
+      ID.WIFE,
+    );
+    const rel2 = makeRelation(
+      'cccccccc-0000-4000-8000-000000000001',
+      RelationType.MARRIED_COUPLE,
+      ID.HUSBAND,
+      ID.SOLO,
+    );
+    const units = buildCoupleUnits([rel1, rel2], new Map());
+    expect(units).toHaveLength(1);
+  });
+});
+
+describe('buildSingleUnits', () => {
+  it('未ユニット化の人物それぞれを single ユニットにする', () => {
+    const people = [makePerson(ID.SOLO), makePerson(ID.CHILD)];
+    const unitOfPerson = new Map<string, string>();
+    const units = buildSingleUnits(people, unitOfPerson);
+    expect(units).toHaveLength(2);
+    expect(units.every((u) => u.type === 'single')).toBe(true);
+  });
+
+  it('既にユニット化済みの人物はスキップする', () => {
+    const people = [makePerson(ID.SOLO), makePerson(ID.CHILD)];
+    const unitOfPerson = new Map<string, string>([[ID.SOLO, 'existing-unit']]);
+    const units = buildSingleUnits(people, unitOfPerson);
+    expect(units).toHaveLength(1);
+    expect(units[0].personIds).toEqual([ID.CHILD]);
+  });
+});
+
+describe('buildChildToParents', () => {
+  it('実子関係は adopted=false で記録する', () => {
+    const rel = makeRelation(
+      ID.REL_PARENT,
+      RelationType.PARENT_CHILD,
+      ID.PARENT,
+      ID.CHILD,
+    );
+    const map = buildChildToParents([rel]);
+    expect(map.get(ID.CHILD)).toEqual([
+      { parentId: ID.PARENT,
+        adopted: false },
+    ]);
+  });
+
+  it('養子関係は adopted=true で記録する', () => {
+    const rel = makeRelation(
+      ID.REL_ADOPTED,
+      RelationType.PARENT_ADOPTED_CHILD,
+      ID.PARENT,
+      ID.CHILD,
+    );
+    const map = buildChildToParents([rel]);
+    expect(map.get(ID.CHILD)).toEqual([
+      { parentId: ID.PARENT,
+        adopted: true },
+    ]);
+  });
+
+  it('1 人の子に複数の親を紐付ける', () => {
+    const rel1 = makeRelation(
+      ID.REL_PARENT,
+      RelationType.PARENT_CHILD,
+      ID.HUSBAND,
+      ID.CHILD,
+    );
+    const rel2 = makeRelation(
+      'bbbbbbbb-0000-4000-8000-000000000003',
+      RelationType.PARENT_CHILD,
+      ID.WIFE,
+      ID.CHILD,
+    );
+    const map = buildChildToParents([rel1, rel2]);
+    const parents = map.get(ID.CHILD) ?? [];
+    expect(parents.map((p) => p.parentId)).toEqual([ID.HUSBAND, ID.WIFE]);
+  });
+
+  it('夫婦/事実婚関係は無視する', () => {
+    const rel = makeRelation(
+      ID.REL_MARRIED,
+      RelationType.MARRIED_COUPLE,
+      ID.HUSBAND,
+      ID.WIFE,
+    );
+    const map = buildChildToParents([rel]);
+    expect(map.size).toBe(0);
+  });
+});

--- a/src/components/familyTree/layout/edgeAnchor.test.ts
+++ b/src/components/familyTree/layout/edgeAnchor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeParentAnchor } from '@/components/familyTree/layout/edgeAnchor';
+import {
+  COUPLE_GAP,
+  GENERATION_GAP,
+  PERSON_HEIGHT,
+  PERSON_WIDTH,
+} from '@/components/familyTree/layout/internalTypes';
+
+describe('computeParentAnchor', () => {
+  it('single は人物中央下端を anchor、busY は次世代まで GENERATION_GAP/2', () => {
+    const result = computeParentAnchor('single', 100, 200);
+    expect(result.x).toBe(100 + (PERSON_WIDTH / 2));
+    expect(result.y).toBe(200 + PERSON_HEIGHT);
+    expect(result.busY).toBe(200 + PERSON_HEIGHT + (GENERATION_GAP / 2));
+  });
+
+  it('couple は二人の間 (高さは中央) を anchor とする', () => {
+    const result = computeParentAnchor('couple', 100, 200);
+    expect(result.x).toBe(100 + PERSON_WIDTH + (COUPLE_GAP / 2));
+    expect(result.y).toBe(200 + (PERSON_HEIGHT / 2));
+    expect(result.busY).toBe(200 + PERSON_HEIGHT + (GENERATION_GAP / 2));
+  });
+});

--- a/src/components/familyTree/layout/generations.test.ts
+++ b/src/components/familyTree/layout/generations.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { assignUnitGenerations } from '@/components/familyTree/layout/generations';
+import {
+  type ParentLink,
+  type Unit,
+} from '@/components/familyTree/layout/internalTypes';
+
+const ID = {
+  GRAND: '11111111-1111-4111-8111-111111111111',
+  PARENT: '22222222-2222-4222-8222-222222222222',
+  CHILD: '33333333-3333-4333-8333-333333333333',
+  A: '44444444-4444-4444-8444-444444444444',
+  B: '55555555-5555-4555-8555-555555555555',
+} as const;
+
+function singleUnit(id: string, personId: string): Unit {
+  return {
+    id,
+    type: 'single',
+    personIds: [personId],
+    marriageRelationId: null,
+    marriageType: null,
+    generation: 0,
+  };
+}
+
+function link(parentId: string): ParentLink {
+  return {
+    parentId,
+    adopted: false,
+  };
+}
+
+describe('assignUnitGenerations', () => {
+  it('親不在は世代 0、子は親+1 になる', () => {
+    const parent = singleUnit('u-parent', ID.PARENT);
+    const child = singleUnit('u-child', ID.CHILD);
+    const units = [parent, child];
+    const childToParents = new Map([[ID.CHILD, [link(ID.PARENT)]]]);
+    assignUnitGenerations(units, childToParents);
+    expect(parent.generation).toBe(0);
+    expect(child.generation).toBe(1);
+  });
+
+  it('複数世代を経るとさらに +1 される', () => {
+    const grand = singleUnit('u-grand', ID.GRAND);
+    const parent = singleUnit('u-parent', ID.PARENT);
+    const child = singleUnit('u-child', ID.CHILD);
+    const units = [grand, parent, child];
+    const childToParents = new Map([
+      [ID.PARENT, [link(ID.GRAND)]],
+      [ID.CHILD, [link(ID.PARENT)]],
+    ]);
+    assignUnitGenerations(units, childToParents);
+    expect(grand.generation).toBe(0);
+    expect(parent.generation).toBe(1);
+    expect(child.generation).toBe(2);
+  });
+
+  it('親子関係に循環参照があれば throw する', () => {
+    const a = singleUnit('u-a', ID.A);
+    const b = singleUnit('u-b', ID.B);
+    const childToParents = new Map([
+      [ID.A, [link(ID.B)]],
+      [ID.B, [link(ID.A)]],
+    ]);
+    expect(() => {
+      assignUnitGenerations([a, b], childToParents);
+    }).toThrow(/循環参照/u);
+  });
+});

--- a/src/components/familyTree/layout/ownership.test.ts
+++ b/src/components/familyTree/layout/ownership.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ParentLink,
+  type Unit,
+} from '@/components/familyTree/layout/internalTypes';
+import {
+  computeOwnership,
+  findAnchorPersonId,
+} from '@/components/familyTree/layout/ownership';
+
+const ID = {
+  PARENT: '11111111-1111-4111-8111-111111111111',
+  CHILD: '22222222-2222-4222-8222-222222222222',
+  HUSBAND: '33333333-3333-4333-8333-333333333333',
+  WIFE: '44444444-4444-4444-8444-444444444444',
+  OUTSIDER: '55555555-5555-4555-8555-555555555555',
+} as const;
+
+function singleUnit(id: string, personId: string): Unit {
+  return {
+    id,
+    type: 'single',
+    personIds: [personId],
+    marriageRelationId: null,
+    marriageType: null,
+    generation: 0,
+  };
+}
+
+function coupleUnit(id: string, p1: string, p2: string): Unit {
+  return {
+    id,
+    type: 'couple',
+    personIds: [p1, p2],
+    marriageRelationId: 'rel',
+    marriageType: 'married',
+    generation: 0,
+  };
+}
+
+function link(parentId: string): ParentLink {
+  return {
+    parentId,
+    adopted: false,
+  };
+}
+
+describe('computeOwnership', () => {
+  it('親不在のユニットは root として扱う', () => {
+    const units = [singleUnit('u-parent', ID.PARENT)];
+    const unitOfPerson = new Map([[ID.PARENT, 'u-parent']]);
+    const result = computeOwnership(units, unitOfPerson, new Map());
+    expect(result.rootUnitIds).toEqual(['u-parent']);
+    expect(result.childrenOfUnit.size).toBe(0);
+  });
+
+  it('単親なら primary owner にのみ記録する', () => {
+    const units = [
+      singleUnit('u-parent', ID.PARENT),
+      singleUnit('u-child', ID.CHILD),
+    ];
+    const unitOfPerson = new Map([
+      [ID.PARENT, 'u-parent'],
+      [ID.CHILD, 'u-child'],
+    ]);
+    const childToParents = new Map([[ID.CHILD, [link(ID.PARENT)]]]);
+    const result = computeOwnership(units, unitOfPerson, childToParents);
+    expect(result.rootUnitIds).toEqual(['u-parent']);
+    expect(result.childrenOfUnit.get('u-parent')).toEqual(['u-child']);
+    expect(result.secondaryParentsOfUnit.size).toBe(0);
+  });
+
+  it('複数の親ユニットがあるとき 2 つ目以降は secondary になる', () => {
+    const units = [
+      coupleUnit('u-couple', ID.HUSBAND, ID.WIFE),
+      singleUnit('u-outsider', ID.OUTSIDER),
+      singleUnit('u-child', ID.CHILD),
+    ];
+    const unitOfPerson = new Map([
+      [ID.HUSBAND, 'u-couple'],
+      [ID.WIFE, 'u-couple'],
+      [ID.OUTSIDER, 'u-outsider'],
+      [ID.CHILD, 'u-child'],
+    ]);
+    const childToParents = new Map([[ID.CHILD, [link(ID.HUSBAND), link(ID.OUTSIDER)]]]);
+    const result = computeOwnership(units, unitOfPerson, childToParents);
+    expect(result.childrenOfUnit.get('u-couple')).toEqual(['u-child']);
+    expect(result.secondaryParentsOfUnit.get('u-child')).toEqual(['u-outsider']);
+  });
+
+  it('同じユニット内の複数の親は重複登録しない', () => {
+    const units = [
+      coupleUnit('u-couple', ID.HUSBAND, ID.WIFE),
+      singleUnit('u-child', ID.CHILD),
+    ];
+    const unitOfPerson = new Map([
+      [ID.HUSBAND, 'u-couple'],
+      [ID.WIFE, 'u-couple'],
+      [ID.CHILD, 'u-child'],
+    ]);
+    const childToParents = new Map([[ID.CHILD, [link(ID.HUSBAND), link(ID.WIFE)]]]);
+    const result = computeOwnership(units, unitOfPerson, childToParents);
+    expect(result.childrenOfUnit.get('u-couple')).toEqual(['u-child']);
+    expect(result.secondaryParentsOfUnit.size).toBe(0);
+  });
+});
+
+describe('findAnchorPersonId', () => {
+  it('childUnit 内で parentUnit に親リンクを持つ人物を返す', () => {
+    const parent = coupleUnit('u-couple', ID.HUSBAND, ID.WIFE);
+    const child = coupleUnit('u-child', ID.CHILD, ID.OUTSIDER);
+    const childToParents = new Map([[ID.CHILD, [link(ID.HUSBAND)]]]);
+    const result = findAnchorPersonId(child, parent, childToParents);
+    expect(result.personId).toBe(ID.CHILD);
+    expect(result.adopted).toBe(false);
+  });
+
+  it('養子なら adopted=true を返す', () => {
+    const parent = singleUnit('u-parent', ID.PARENT);
+    const child = singleUnit('u-child', ID.CHILD);
+    const childToParents = new Map([
+      [
+        ID.CHILD,
+        [
+          { parentId: ID.PARENT,
+            adopted: true },
+        ],
+      ],
+    ]);
+    const result = findAnchorPersonId(child, parent, childToParents);
+    expect(result.adopted).toBe(true);
+  });
+
+  it('該当リンクがなければ childUnit の最初の人物を返す (adopted=false)', () => {
+    const parent = singleUnit('u-other', ID.OUTSIDER);
+    const child = coupleUnit('u-child', ID.CHILD, ID.HUSBAND);
+    const result = findAnchorPersonId(child, parent, new Map());
+    expect(result.personId).toBe(ID.CHILD);
+    expect(result.adopted).toBe(false);
+  });
+});

--- a/src/components/familyTree/layout/secondaryParents.test.ts
+++ b/src/components/familyTree/layout/secondaryParents.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COUPLE_GAP,
+  GENERATION_GAP,
+  type ParentLink,
+  PERSON_HEIGHT,
+  PERSON_WIDTH,
+  type PersonPosition,
+  type PlacementCtx,
+  type Unit,
+} from '@/components/familyTree/layout/internalTypes';
+import { buildSecondaryParentEdges } from '@/components/familyTree/layout/secondaryParents';
+
+const ID = {
+  HUSBAND: '11111111-1111-4111-8111-111111111111',
+  WIFE: '22222222-2222-4222-8222-222222222222',
+  OUTSIDER: '33333333-3333-4333-8333-333333333333',
+  CHILD: '44444444-4444-4444-8444-444444444444',
+} as const;
+
+function singleUnit(id: string, personId: string): Unit {
+  return {
+    id,
+    type: 'single',
+    personIds: [personId],
+    marriageRelationId: null,
+    marriageType: null,
+    generation: 0,
+  };
+}
+
+function coupleUnit(id: string, p1: string, p2: string): Unit {
+  return {
+    id,
+    type: 'couple',
+    personIds: [p1, p2],
+    marriageRelationId: 'rel',
+    marriageType: 'married',
+    generation: 0,
+  };
+}
+
+function buildCtx(
+  units: Unit[],
+  secondaryParentsOfUnit: Map<string, string[]>,
+  childToParents: Map<string, ParentLink[]>,
+  personPositions: Map<string, PersonPosition>,
+): PlacementCtx {
+  return {
+    unitMap: new Map(units.map((u) => [u.id, u])),
+    childrenOfUnit: new Map(),
+    secondaryParentsOfUnit,
+    subtreeWidths: new Map(),
+    childToParents,
+    showFamilyNameMap: new Map(),
+    nodes: [],
+    marriageEdges: [],
+    parentGroups: [],
+    secondaryParentEdges: [],
+    personPositions,
+  };
+}
+
+describe('buildSecondaryParentEdges', () => {
+  it('secondary parent との edge を生成する (single 親、実子)', () => {
+    const couple = coupleUnit('u-couple', ID.HUSBAND, ID.WIFE);
+    const outsider = singleUnit('u-outsider', ID.OUTSIDER);
+    const child = singleUnit('u-child', ID.CHILD);
+    const childToParents = new Map<string, ParentLink[]>([
+      [
+        ID.CHILD,
+        [
+          { parentId: ID.HUSBAND,
+            adopted: false },
+          { parentId: ID.OUTSIDER,
+            adopted: false },
+        ],
+      ],
+    ]);
+    const personPositions = new Map<string, PersonPosition>([
+      [
+        ID.HUSBAND, { x: 0,
+          y: 0 },
+      ],
+      [
+        ID.WIFE, { x: PERSON_WIDTH + COUPLE_GAP,
+          y: 0 },
+      ],
+      [
+        ID.OUTSIDER, { x: 300,
+          y: 0 },
+      ],
+      [
+        ID.CHILD, { x: 150,
+          y: 200 },
+      ],
+    ]);
+    const ctx = buildCtx(
+      [couple, outsider, child],
+      new Map([[child.id, [outsider.id]]]),
+      childToParents,
+      personPositions,
+    );
+    const edges = buildSecondaryParentEdges(ctx);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].id).toBe('u-outsider__u-child');
+    expect(edges[0].parentAnchorX).toBe(300 + (PERSON_WIDTH / 2));
+    expect(edges[0].parentAnchorY).toBe(PERSON_HEIGHT);
+    expect(edges[0].busY).toBe(PERSON_HEIGHT + (GENERATION_GAP / 2));
+    expect(edges[0].childX).toBe(150 + (PERSON_WIDTH / 2));
+    expect(edges[0].childTopY).toBe(200);
+    expect(edges[0].adopted).toBe(false);
+  });
+
+  it('養子なら adopted=true で edge を作る', () => {
+    const outsider = singleUnit('u-outsider', ID.OUTSIDER);
+    const child = singleUnit('u-child', ID.CHILD);
+    const childToParents = new Map<string, ParentLink[]>([
+      [
+        ID.CHILD, [
+          { parentId: ID.OUTSIDER,
+            adopted: true },
+        ],
+      ],
+    ]);
+    const personPositions = new Map<string, PersonPosition>([
+      [
+        ID.OUTSIDER, { x: 0,
+          y: 0 },
+      ],
+      [
+        ID.CHILD, { x: 100,
+          y: 200 },
+      ],
+    ]);
+    const ctx = buildCtx(
+      [outsider, child],
+      new Map([[child.id, [outsider.id]]]),
+      childToParents,
+      personPositions,
+    );
+    const edges = buildSecondaryParentEdges(ctx);
+    expect(edges[0].adopted).toBe(true);
+  });
+
+  it('座標が未確定の場合は edge をスキップする', () => {
+    const outsider = singleUnit('u-outsider', ID.OUTSIDER);
+    const child = singleUnit('u-child', ID.CHILD);
+    const childToParents = new Map<string, ParentLink[]>([
+      [
+        ID.CHILD, [
+          { parentId: ID.OUTSIDER,
+            adopted: false },
+        ],
+      ],
+    ]);
+    const ctx = buildCtx(
+      [outsider, child],
+      new Map([[child.id, [outsider.id]]]),
+      childToParents,
+      new Map(),
+    );
+    expect(buildSecondaryParentEdges(ctx)).toEqual([]);
+  });
+});

--- a/src/components/familyTree/layout/sortChildren.test.ts
+++ b/src/components/familyTree/layout/sortChildren.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ParentLink,
+  type Unit,
+} from '@/components/familyTree/layout/internalTypes';
+import { sortChildrenByBirth } from '@/components/familyTree/layout/sortChildren';
+import { type Person, Sex } from '@/schemas/personSchema';
+
+const ID = {
+  PARENT: '11111111-1111-4111-8111-111111111111',
+  YOUNGER: '22222222-2222-4222-8222-222222222222',
+  ELDER: '33333333-3333-4333-8333-333333333333',
+  NO_BIRTH: '44444444-4444-4444-8444-444444444444',
+} as const;
+
+function makePerson(id: string, birth: string): Person {
+  return {
+    id,
+    familyName: '姓',
+    givenName: '名',
+    familyNameKana: 'カナ',
+    givenNameKana: 'カナ',
+    sex: Sex.UNKNOWN,
+    birth,
+    death: '',
+  };
+}
+
+function singleUnit(id: string, personId: string): Unit {
+  return {
+    id,
+    type: 'single',
+    personIds: [personId],
+    marriageRelationId: null,
+    marriageType: null,
+    generation: 0,
+  };
+}
+
+function link(parentId: string): ParentLink {
+  return {
+    parentId,
+    adopted: false,
+  };
+}
+
+describe('sortChildrenByBirth', () => {
+  it('生年月日が新しい (= 若い) ほど先頭、古い (= 年長) ほど末尾になる', () => {
+    const parent = singleUnit('u-parent', ID.PARENT);
+    const younger = singleUnit('u-younger', ID.YOUNGER);
+    const elder = singleUnit('u-elder', ID.ELDER);
+    const unitMap = new Map([
+      [parent.id, parent],
+      [younger.id, younger],
+      [elder.id, elder],
+    ]);
+    const childToParents = new Map([
+      [ID.YOUNGER, [link(ID.PARENT)]],
+      [ID.ELDER, [link(ID.PARENT)]],
+    ]);
+    const personMap = new Map([
+      [ID.YOUNGER, makePerson(ID.YOUNGER, '2010-01-01')],
+      [ID.ELDER, makePerson(ID.ELDER, '2000-01-01')],
+    ]);
+    const childrenOfUnit = new Map([[parent.id, [elder.id, younger.id]]]);
+    sortChildrenByBirth(childrenOfUnit, unitMap, childToParents, personMap);
+    expect(childrenOfUnit.get(parent.id)).toEqual([younger.id, elder.id]);
+  });
+
+  it('生年月日不明 (空文字) は先頭側に並ぶ', () => {
+    const parent = singleUnit('u-parent', ID.PARENT);
+    const known = singleUnit('u-known', ID.YOUNGER);
+    const unknown = singleUnit('u-unknown', ID.NO_BIRTH);
+    const unitMap = new Map([
+      [parent.id, parent],
+      [known.id, known],
+      [unknown.id, unknown],
+    ]);
+    const childToParents = new Map([
+      [ID.YOUNGER, [link(ID.PARENT)]],
+      [ID.NO_BIRTH, [link(ID.PARENT)]],
+    ]);
+    const personMap = new Map([
+      [ID.YOUNGER, makePerson(ID.YOUNGER, '2000-01-01')],
+      [ID.NO_BIRTH, makePerson(ID.NO_BIRTH, '')],
+    ]);
+    const childrenOfUnit = new Map([[parent.id, [known.id, unknown.id]]]);
+    sortChildrenByBirth(childrenOfUnit, unitMap, childToParents, personMap);
+    expect(childrenOfUnit.get(parent.id)).toEqual([unknown.id, known.id]);
+  });
+
+  it('親ユニットが存在しなければソートをスキップする', () => {
+    const childrenOfUnit = new Map([['missing-parent', ['a', 'b']]]);
+    sortChildrenByBirth(childrenOfUnit, new Map(), new Map(), new Map());
+    expect(childrenOfUnit.get('missing-parent')).toEqual(['a', 'b']);
+  });
+});

--- a/src/components/familyTree/layout/subtreeWidth.test.ts
+++ b/src/components/familyTree/layout/subtreeWidth.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COUPLE_GAP,
+  PERSON_WIDTH,
+  type Unit,
+  UNIT_GAP,
+} from '@/components/familyTree/layout/internalTypes';
+import {
+  computeSubtreeWidth,
+  unitOwnWidth,
+} from '@/components/familyTree/layout/subtreeWidth';
+
+function singleUnit(id: string): Unit {
+  return {
+    id,
+    type: 'single',
+    personIds: [`p-${id}`],
+    marriageRelationId: null,
+    marriageType: null,
+    generation: 0,
+  };
+}
+
+function coupleUnit(id: string): Unit {
+  return {
+    id,
+    type: 'couple',
+    personIds: [`p1-${id}`, `p2-${id}`],
+    marriageRelationId: 'rel',
+    marriageType: 'married',
+    generation: 0,
+  };
+}
+
+describe('unitOwnWidth', () => {
+  it('single は PERSON_WIDTH', () => {
+    expect(unitOwnWidth(singleUnit('a'))).toBe(PERSON_WIDTH);
+  });
+
+  it('couple は PERSON_WIDTH*2 + COUPLE_GAP', () => {
+    expect(unitOwnWidth(coupleUnit('a'))).toBe((PERSON_WIDTH * 2) + COUPLE_GAP);
+  });
+});
+
+describe('computeSubtreeWidth', () => {
+  it('葉ユニットは自身の幅を返す', () => {
+    const unit = singleUnit('leaf');
+    const unitMap = new Map([[unit.id, unit]]);
+    const width = computeSubtreeWidth(unit.id, unitMap, new Map(), new Map());
+    expect(width).toBe(PERSON_WIDTH);
+  });
+
+  it('子が複数あるときは子の合計幅 + UNIT_GAP * (n-1) を採用する', () => {
+    const root = singleUnit('root');
+    const child1 = singleUnit('c1');
+    const child2 = singleUnit('c2');
+    const unitMap = new Map([
+      [root.id, root],
+      [child1.id, child1],
+      [child2.id, child2],
+    ]);
+    const childrenOfUnit = new Map([[root.id, [child1.id, child2.id]]]);
+    const width = computeSubtreeWidth(root.id, unitMap, childrenOfUnit, new Map());
+    expect(width).toBe((PERSON_WIDTH * 2) + UNIT_GAP);
+  });
+
+  it('自身の幅の方が子合計より大きい場合は自身の幅を採用する', () => {
+    const root = coupleUnit('root');
+    const child = singleUnit('c');
+    const unitMap = new Map([[root.id, root], [child.id, child]]);
+    const childrenOfUnit = new Map([[root.id, [child.id]]]);
+    const width = computeSubtreeWidth(root.id, unitMap, childrenOfUnit, new Map());
+    expect(width).toBe((PERSON_WIDTH * 2) + COUPLE_GAP);
+  });
+
+  it('memo で同じユニットの計算結果は再利用される', () => {
+    const root = singleUnit('root');
+    const unitMap = new Map([[root.id, root]]);
+    const memo = new Map<string, number>();
+    computeSubtreeWidth(root.id, unitMap, new Map(), memo);
+    expect(memo.get(root.id)).toBe(PERSON_WIDTH);
+  });
+
+  it('存在しないユニットは 0 を返す', () => {
+    const width = computeSubtreeWidth('missing', new Map(), new Map(), new Map());
+    expect(width).toBe(0);
+  });
+});

--- a/src/components/familyTree/layoutFamilyTree.test.ts
+++ b/src/components/familyTree/layoutFamilyTree.test.ts
@@ -94,10 +94,12 @@ describe('layoutFamilyTree', () => {
       parentRel(ID.REL_PARENT_NEW_H, ID.HUSBAND, ID.CHILD_NEW),
     ];
     const result = layoutFamilyTree(people, relations);
-    const xByPerson = new Map(result.nodes.map((n) => [n.personId, n.x]));
-    const xOld = xByPerson.get(ID.CHILD_OLD) ?? 0;
-    const xNew = xByPerson.get(ID.CHILD_NEW) ?? 0;
-    expect(xOld).toBeGreaterThan(xNew);
+    const oldNode = result.nodes.find((n) => n.personId === ID.CHILD_OLD);
+    const newNode = result.nodes.find((n) => n.personId === ID.CHILD_NEW);
+    if (oldNode === undefined || newNode === undefined) {
+      throw new Error('期待した子ノードが見つかりません');
+    }
+    expect(oldNode.x).toBeGreaterThan(newNode.x);
   });
 
   it('存在しない人物を参照する relation は無視する', () => {

--- a/src/components/familyTree/layoutFamilyTree.test.ts
+++ b/src/components/familyTree/layoutFamilyTree.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { layoutFamilyTree } from '@/components/familyTree/layoutFamilyTree';
+import { type Person, Sex } from '@/schemas/personSchema';
+import { type Relation, RelationType } from '@/schemas/relationSchema';
+
+const ID = {
+  HUSBAND: '11111111-1111-4111-8111-111111111111',
+  WIFE: '22222222-2222-4222-8222-222222222222',
+  CHILD_OLD: '33333333-3333-4333-8333-333333333333',
+  CHILD_NEW: '44444444-4444-4444-8444-444444444444',
+  REL_MARRIED: 'aaaaaaaa-0000-4000-8000-000000000001',
+  REL_PARENT_OLD_H: 'bbbbbbbb-0000-4000-8000-000000000001',
+  REL_PARENT_OLD_W: 'bbbbbbbb-0000-4000-8000-000000000002',
+  REL_PARENT_NEW_H: 'bbbbbbbb-0000-4000-8000-000000000003',
+  REL_PARENT_NEW_W: 'bbbbbbbb-0000-4000-8000-000000000004',
+} as const;
+
+function person(id: string, birth: string): Person {
+  return {
+    id,
+    familyName: '山田',
+    givenName: '名',
+    familyNameKana: 'ヤマダ',
+    givenNameKana: 'ナ',
+    sex: Sex.UNKNOWN,
+    birth,
+    death: '',
+  };
+}
+
+function marriedRel(id: string, p1: string, p2: string): Relation {
+  return {
+    id,
+    relationType: [RelationType.MARRIED_COUPLE],
+    persons: {
+      personId1: [p1],
+      personId2: [p2],
+    },
+  };
+}
+
+function parentRel(id: string, parent: string, child: string): Relation {
+  return {
+    id,
+    relationType: [RelationType.PARENT_CHILD],
+    persons: {
+      personId1: [parent],
+      personId2: [child],
+    },
+  };
+}
+
+describe('layoutFamilyTree', () => {
+  it('人物 0 件なら空のレイアウトを返す', () => {
+    const result = layoutFamilyTree([], []);
+    expect(result.nodes).toEqual([]);
+    expect(result.width).toBe(0);
+    expect(result.height).toBe(0);
+  });
+
+  it('夫婦+2 児: 世代 / ノード数 / parentGroups が期待通り', () => {
+    const people = [
+      person(ID.HUSBAND, '1970-01-01'),
+      person(ID.WIFE, '1972-01-01'),
+      person(ID.CHILD_OLD, '2000-01-01'),
+      person(ID.CHILD_NEW, '2005-01-01'),
+    ];
+    const relations = [
+      marriedRel(ID.REL_MARRIED, ID.HUSBAND, ID.WIFE),
+      parentRel(ID.REL_PARENT_OLD_H, ID.HUSBAND, ID.CHILD_OLD),
+      parentRel(ID.REL_PARENT_OLD_W, ID.WIFE, ID.CHILD_OLD),
+      parentRel(ID.REL_PARENT_NEW_H, ID.HUSBAND, ID.CHILD_NEW),
+      parentRel(ID.REL_PARENT_NEW_W, ID.WIFE, ID.CHILD_NEW),
+    ];
+    const result = layoutFamilyTree(people, relations);
+    expect(result.nodes).toHaveLength(4);
+    expect(result.generationRows).toHaveLength(2);
+    expect(result.marriageEdges).toHaveLength(1);
+    expect(result.parentGroups).toHaveLength(1);
+    expect(result.parentGroups[0].children).toHaveLength(2);
+  });
+
+  it('兄弟の並び順は年長 (= 古い生年) が右側 (x が大きい) になる', () => {
+    const people = [
+      person(ID.HUSBAND, '1970-01-01'),
+      person(ID.WIFE, '1972-01-01'),
+      person(ID.CHILD_OLD, '2000-01-01'),
+      person(ID.CHILD_NEW, '2005-01-01'),
+    ];
+    const relations = [
+      marriedRel(ID.REL_MARRIED, ID.HUSBAND, ID.WIFE),
+      parentRel(ID.REL_PARENT_OLD_H, ID.HUSBAND, ID.CHILD_OLD),
+      parentRel(ID.REL_PARENT_NEW_H, ID.HUSBAND, ID.CHILD_NEW),
+    ];
+    const result = layoutFamilyTree(people, relations);
+    const xByPerson = new Map(result.nodes.map((n) => [n.personId, n.x]));
+    const xOld = xByPerson.get(ID.CHILD_OLD) ?? 0;
+    const xNew = xByPerson.get(ID.CHILD_NEW) ?? 0;
+    expect(xOld).toBeGreaterThan(xNew);
+  });
+
+  it('存在しない人物を参照する relation は無視する', () => {
+    const people = [person(ID.HUSBAND, '')];
+    const relations = [marriedRel(ID.REL_MARRIED, ID.HUSBAND, ID.WIFE)];
+    const result = layoutFamilyTree(people, relations);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.marriageEdges).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `src/components/familyTree/layout/` 配下の純粋関数に unit test を 7 ファイル追加 (計 35 ケース)
- `layoutFamilyTree` の統合テスト 4 ケースを追加 (空 / 夫婦+2 児 / 兄弟ソート / 不正 relation 無視)
- 新規追加 39 ケース → テスト総数 4 → 43

## 追加したテストファイル
- `layout/buildUnits.test.ts` (10 ケース) — buildCoupleUnits / buildSingleUnits / buildChildToParents
- `layout/ownership.test.ts` (7 ケース) — computeOwnership / findAnchorPersonId
- `layout/subtreeWidth.test.ts` (7 ケース) — unitOwnWidth / computeSubtreeWidth
- `layout/sortChildren.test.ts` (3 ケース) — sortChildrenByBirth
- `layout/generations.test.ts` (3 ケース) — assignUnitGenerations (循環参照 throw 含む)
- `layout/edgeAnchor.test.ts` (2 ケース) — computeParentAnchor
- `layout/secondaryParents.test.ts` (3 ケース) — buildSecondaryParentEdges
- `layoutFamilyTree.test.ts` (4 ケース) — 統合テスト

## Test plan
- [x] `yarn test` (43/43 passed)
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`

Closes #81