### PR TITLE
[#95] commitlint をローカル commit-msg フックでも実行する

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+# commitlint をローカルで実行する commit-msg フック。
+# 有効化: `yarn hooks:install` (= git config core.hooksPath .githooks)
+yarn commitlint --edit "$1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@
 - コミットメッセージ: `[#<issue>]<type>: <説明>` 形式。type は `add` / `update` / `fix` / `refactor` / `docs`
 - **`Co-Authored-By:` トレーラーは付けない** (Claude Code のデフォルト指示を上書き)
 - 1 PR を論理的に複数コミットに分割する (機能追加とサンプルデータ更新を分ける等)
+- ローカルでは `.githooks/commit-msg` (有効化: `yarn hooks:install`) が commitlint を走らせて形式違反を弾く。CI と同じ検証
 
 ### PR
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ Node.js のバージョンは [`.node-version`](./.node-version) に固定。[no
 ```bash
 corepack enable          # 初回のみ
 yarn install
+yarn hooks:install       # 初回のみ。commit-msg フックを有効化
 yarn dev
 ```
 
 利用可能なスクリプトは `package.json` の `scripts` を参照 (`yarn dev` / `yarn build` / `yarn lint` / `yarn test` 等)。
+
+### Git フック
+
+`yarn hooks:install` を 1 度実行すると、`.githooks/commit-msg` がコミット時に commitlint を走らせ、`[#<issue>]<type>: <説明>` 形式から外れたメッセージを弾く。CI と同等の検証をローカルでも行えるので push 前のリトライを減らせる。
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ yarn dev
 
 `yarn hooks:install` を 1 度実行すると、`.githooks/commit-msg` がコミット時に commitlint を走らせ、`[#<issue>]<type>: <説明>` 形式から外れたメッセージを弾く。CI と同等の検証をローカルでも行えるので push 前のリトライを減らせる。
 
+> [!NOTE]
+> 仕組みは `git config core.hooksPath .githooks` (リポジトリローカル)。**この設定が有効な間は `.git/hooks/*` に置いた既存フックは実行されない**ので、すでに別のフックを使っている場合は注意。元に戻すには `git config --unset core.hooksPath` を実行する。
+
 ## ドキュメント
 
 - [docs/family-tree.md](docs/family-tree.md) — 家系図の表記ルール

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "eslint --fix --quiet .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "hooks:install": "git config core.hooksPath .githooks"
   },
   "dependencies": {
     "@chakra-ui/react": "^3.13.0",


### PR DESCRIPTION
## Summary
- `.githooks/commit-msg` に `yarn commitlint --edit` を呼ぶシェルスクリプトを追加
- `yarn hooks:install` で `git config core.hooksPath .githooks` を実行する setup スクリプトを追加 (初回のみ)
- 依存パッケージは追加せず (`.yarnrc.yml` の `enableScripts: false` を維持)、husky / simple-git-hooks を避けてサプライチェーン面を最小化
- README にセットアップ手順を追記、CLAUDE.md にフックの存在を明記

## 動作確認
- 形式違反 (`bad message`) でコミットしようとするとフックが弾く
- 正しい形式 (`[#95]add: ...`) ではコミットが通る (本 PR のコミット自体がフック適用後に作成された)

## Test plan
- [x] `yarn hooks:install` で `core.hooksPath` が `.githooks` に設定される
- [x] 形式違反のメッセージは commit-msg フックで弾かれる
- [x] 正しい形式のメッセージは通る
- [x] `yarn lint` / `yarn test` / `yarn tsc`

Closes #95