### PR TITLE
[#143] PersonNode を最小表示にし詳細を Tooltip へ

### DIFF
--- a/src/components/familyTree/PersonNode.test.tsx
+++ b/src/components/familyTree/PersonNode.test.tsx
@@ -89,4 +89,35 @@ describe('PersonNode', () => {
     await user.keyboard('{Enter}');
     expect(onClick).toHaveBeenCalledExactlyOnceWith(ID);
   });
+
+  it('ノード内の text 要素は主名のみで、日付/戒名はインラインで描画しない', () => {
+    renderNode({
+      person: makePerson({
+        birth: '1980-01-01',
+        death: '2020-01-01',
+        posthumousName: '釋浄信',
+        maidenName: '鈴木',
+      }),
+    });
+    const svgTexts = Array.from(document.querySelectorAll('svg text'));
+    expect(svgTexts).toHaveLength(1);
+    expect(svgTexts[0]?.textContent).toBe('山田 太郎');
+  });
+
+  it('詳細情報のある人物はホバーで tooltip に旧姓/生没年/戒名が表示される', async() => {
+    const user = userEvent.setup();
+    renderNode({
+      person: makePerson({
+        birth: '1980-01-01',
+        death: '2020-01-01',
+        posthumousName: '釋浄信',
+        maidenName: '鈴木',
+      }),
+      onClick: vi.fn(),
+    });
+    await user.hover(screen.getByRole('button'));
+    expect(await screen.findByText('1980 - 2020')).toBeInTheDocument();
+    expect(screen.getByText('鈴木')).toBeInTheDocument();
+    expect(screen.getByText('釋浄信')).toBeInTheDocument();
+  });
 });

--- a/src/components/familyTree/PersonNode.test.tsx
+++ b/src/components/familyTree/PersonNode.test.tsx
@@ -120,4 +120,21 @@ describe('PersonNode', () => {
     expect(screen.getByText('鈴木')).toBeInTheDocument();
     expect(screen.getByText('釋浄信')).toBeInTheDocument();
   });
+
+  it('詳細が一切無い人物 (生没年/旧姓/戒名すべて空) は tooltip を持たない', async() => {
+    const user = userEvent.setup();
+    renderNode({
+      person: makePerson({
+        birth: '',
+        death: '',
+        posthumousName: '',
+        maidenName: undefined,
+      }),
+      onClick: vi.fn(),
+    });
+    await user.hover(screen.getByRole('button'));
+    // 性別はノードの色で表現されるので、tooltip 単独では出さない。
+    expect(screen.queryByText('性別')).not.toBeInTheDocument();
+    expect(screen.queryByText('男性')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -46,6 +46,11 @@ interface DetailRow {
   value: string;
 }
 
+/*
+ * 性別はノードの色で既に表現されている。tooltip では情報の重複を避けつつ、
+ * 他に表示する詳細 (旧姓/生没年/戒名) があるときだけ、ラベル形式で改めて補足する。
+ * したがって性別だけでは tooltip を出さない (= rows が空) ようにする。
+ */
 function buildDetailRows(person: Person): DetailRow[] {
   const rows: DetailRow[] = [];
   const maiden = (person.maidenName ?? '').trim();
@@ -53,13 +58,6 @@ function buildDetailRows(person: Person): DetailRow[] {
     rows.push({
       label: '旧姓',
       value: maiden,
-    });
-  }
-  const sexLabel = sexList.find((s) => s.value === toSex(person.sex))?.label;
-  if (sexLabel !== undefined) {
-    rows.push({
-      label: '性別',
-      value: sexLabel,
     });
   }
   const dateText = buildDateText(person.birth, person.death);
@@ -74,6 +72,17 @@ function buildDetailRows(person: Person): DetailRow[] {
     rows.push({
       label: '戒名',
       value: posthumousName,
+    });
+  }
+  if (rows.length === 0) {
+    return rows;
+  }
+  const sexLabel = sexList.find((s) => s.value === toSex(person.sex))?.label;
+  if (sexLabel !== undefined) {
+    // 性別は旧姓の直後に挿入する (元の並び順を維持)。
+    rows.splice(maiden === '' ? 0 : 1, 0, {
+      label: '性別',
+      value: sexLabel,
     });
   }
   return rows;

--- a/src/components/familyTree/PersonNode.tsx
+++ b/src/components/familyTree/PersonNode.tsx
@@ -1,8 +1,9 @@
+import { Box, Portal, Tooltip } from '@chakra-ui/react';
 import React from 'react';
 
 import { type PersonNodeLayout } from '@/components/familyTree/types';
 import { useFamilyTreeTheme } from '@/components/familyTree/useFamilyTreeTheme';
-import { type Person, Sex } from '@/schemas/personSchema';
+import { type Person, Sex, sexList } from '@/schemas/personSchema';
 
 interface Props {
   node: PersonNodeLayout;
@@ -10,9 +11,7 @@ interface Props {
   person: Person;
 }
 
-const NAME_Y_RATIO = 0.29;
-const DATE_Y_RATIO = 0.55;
-const POSTHUMOUS_Y_RATIO = 0.79;
+const NAME_Y_RATIO = 0.55;
 const DECEASED_RECT_OPACITY = 0.45;
 const DECEASED_TEXT_OPACITY = 0.75;
 
@@ -42,22 +41,56 @@ function buildDateText(birth: string, death: string): string {
   return `${b} - ${d}`;
 }
 
+interface DetailRow {
+  label: string;
+  value: string;
+}
+
+function buildDetailRows(person: Person): DetailRow[] {
+  const rows: DetailRow[] = [];
+  const maiden = (person.maidenName ?? '').trim();
+  if (maiden !== '') {
+    rows.push({
+      label: '旧姓',
+      value: maiden,
+    });
+  }
+  const sexLabel = sexList.find((s) => s.value === toSex(person.sex))?.label;
+  if (sexLabel !== undefined) {
+    rows.push({
+      label: '性別',
+      value: sexLabel,
+    });
+  }
+  const dateText = buildDateText(person.birth, person.death);
+  if (dateText !== '') {
+    rows.push({
+      label: '生没年',
+      value: dateText,
+    });
+  }
+  const posthumousName = (person.posthumousName ?? '').trim();
+  if (posthumousName !== '') {
+    rows.push({
+      label: '戒名',
+      value: posthumousName,
+    });
+  }
+  return rows;
+}
+
 export function PersonNode({ node, onClick, person }: Props): React.ReactNode {
   const theme = useFamilyTreeTheme();
   const fill = theme.sexFill[toSex(person.sex)];
   const fullName = node.showFamilyName
     ? `${person.familyName} ${person.givenName}`
     : person.givenName;
-  const dateText = buildDateText(person.birth, person.death);
-  const posthumousName = (person.posthumousName ?? '').trim();
   const isDeceased = person.death !== '';
   const rectOpacity = isDeceased ? DECEASED_RECT_OPACITY : 1;
   const textOpacity = isDeceased ? DECEASED_TEXT_OPACITY : 1;
   const transform = `translate(${node.x.toString()}, ${node.y.toString()})`;
   const centerX = node.width / 2;
   const nameY = node.height * NAME_Y_RATIO;
-  const dateY = node.height * DATE_Y_RATIO;
-  const posthumousY = node.height * POSTHUMOUS_Y_RATIO;
   const isClickable = onClick !== undefined;
   const handleClick = !isClickable
     ? undefined
@@ -71,7 +104,9 @@ export function PersonNode({ node, onClick, person }: Props): React.ReactNode {
       }
     };
   const ariaLabel = `${person.familyName} ${person.givenName}`;
-  return (
+  const detailRows = buildDetailRows(person);
+
+  const node$ = (
     <g
       aria-label={isClickable ? ariaLabel : undefined}
       onClick={handleClick}
@@ -103,36 +138,50 @@ export function PersonNode({ node, onClick, person }: Props): React.ReactNode {
       >
         {fullName}
       </text>
-
-      {dateText === ''
-        ? null
-        : (
-          <text
-            fill={theme.dateFill}
-            fillOpacity={textOpacity}
-            fontSize={11}
-            textAnchor="middle"
-            x={centerX}
-            y={dateY}
-          >
-            {dateText}
-          </text>
-        )}
-
-      {posthumousName === ''
-        ? null
-        : (
-          <text
-            fill={theme.dateFill}
-            fillOpacity={textOpacity}
-            fontSize={10}
-            textAnchor="middle"
-            x={centerX}
-            y={posthumousY}
-          >
-            {posthumousName}
-          </text>
-        )}
     </g>
+  );
+
+  if (detailRows.length === 0) {
+    return node$;
+  }
+
+  return (
+    <Tooltip.Root openDelay={150}>
+      <Tooltip.Trigger asChild>
+        {node$}
+      </Tooltip.Trigger>
+
+      <Portal>
+        <Tooltip.Positioner>
+          <Tooltip.Content>
+            <Tooltip.Arrow>
+              <Tooltip.ArrowTip />
+            </Tooltip.Arrow>
+
+            <Box minWidth="180px">
+              <Box
+                fontWeight={600}
+                marginBottom={1}
+              >
+                {`${person.familyName} ${person.givenName}`}
+              </Box>
+
+              {detailRows.map((row) => (
+                <Box
+                  display="flex"
+                  fontSize="xs"
+                  gap={2}
+                  justifyContent="space-between"
+                  key={row.label}
+                >
+                  <Box color="fg.muted">{row.label}</Box>
+                  <Box>{row.value}</Box>
+                </Box>
+              ))}
+            </Box>
+          </Tooltip.Content>
+        </Tooltip.Positioner>
+      </Portal>
+    </Tooltip.Root>
   );
 }


### PR DESCRIPTION
## Summary
- ノード内の描画は **主名のみ** に縮小。日付 / 旧姓 / 戒名は SVG text として描かない (はみ出し問題の根本解決)
- ホバー (focus) で **Chakra v3 Tooltip** にラベル付きで「旧姓 / 性別 / 生没年 / 戒名」を表示
- 詳細が 1 件もない人物 (生年没年/旧姓/戒名のいずれも未設定) は Tooltip ラップをスキップし軽量に描画
- 性別の色塗りと故人の opacity は引き続きノードで at-a-glance に保つ

## エクスポート時の挙動
- PNG: ノードに描かれた主名のみが保存される。日付・戒名・旧姓は画像から外れる (= 意図的な小型化)
- SVG: 出力に Tooltip 用の HTML は含まれないので同様。詳細が必要な場合は別途人物一覧の出力を検討 (将来 issue)

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] `yarn test` (78/78 — PersonNode: 最小描画と tooltip 表示の 2 ケース追加)
- [x] `yarn build`
- [ ] ブラウザでサンプル読込 → ノードがコンパクト + ホバーで詳細が出るか確認
- [ ] 鈴木 美咲 (旧姓 鈴木) で Tooltip に「旧姓 鈴木」が表示されるか確認

Closes #143