### PR TITLE
[#55] 家系図に起点人物フィルタ (祖先/子孫/両方) を追加

### DIFF
--- a/src/components/familyTree/FamilyTree.test.tsx
+++ b/src/components/familyTree/FamilyTree.test.tsx
@@ -65,6 +65,46 @@ const MARRIAGE: Relation = {
   },
 };
 
+const CHILD: Person = {
+  id: '33333333-3333-4333-8333-333333333333',
+  familyName: '山田',
+  givenName: '一郎',
+  familyNameKana: 'ヤマダ',
+  givenNameKana: 'イチロウ',
+  sex: Sex.MALE,
+  birth: '2000-01-01',
+  death: '',
+};
+
+const OUTSIDER: Person = {
+  id: '44444444-4444-4444-8444-444444444444',
+  familyName: '佐藤',
+  givenName: '次郎',
+  familyNameKana: 'サトウ',
+  givenNameKana: 'ジロウ',
+  sex: Sex.MALE,
+  birth: '1990-01-01',
+  death: '',
+};
+
+const PARENT_REL_HUSBAND: Relation = {
+  id: 'bbbbbbbb-0000-4000-8000-000000000001',
+  relationType: [RelationType.PARENT_CHILD],
+  persons: {
+    personId1: [HUSBAND.id],
+    personId2: [CHILD.id],
+  },
+};
+
+const PARENT_REL_WIFE: Relation = {
+  id: 'bbbbbbbb-0000-4000-8000-000000000002',
+  relationType: [RelationType.PARENT_CHILD],
+  persons: {
+    personId1: [WIFE.id],
+    personId2: [CHILD.id],
+  },
+};
+
 describe('FamilyTree', () => {
   beforeEach(() => {
     usePeopleStore.setState({ people: [] });
@@ -97,5 +137,29 @@ describe('FamilyTree', () => {
     await user.click(screen.getByRole('button', { name: '山田 太郎' }));
     const dialog = await screen.findByTestId('person-dialog');
     expect(dialog).toHaveTextContent('山田 太郎');
+  });
+
+  it('フィルタで起点人物を選ぶと該当系統だけが描画され、クリアで戻る', async() => {
+    usePeopleStore.setState({ people: [HUSBAND, WIFE, CHILD, OUTSIDER] });
+    useRelationStore.setState({ relations: [MARRIAGE, PARENT_REL_HUSBAND, PARENT_REL_WIFE] });
+    const user = userEvent.setup();
+    renderWithProvider(<FamilyTree />);
+    // 初期状態: 4 人とも (家系図ノード = 山田 3 名 + 血縁の無い 佐藤 次郎) が描画
+    expect(screen.getByRole('button', { name: '山田 太郎' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '佐藤 次郎' })).toBeInTheDocument();
+
+    // フィルタの起点人物セレクタを開いて 山田 一郎 を選択
+    await user.click(screen.getByText('起点人物を選択'));
+    await user.click(await screen.findByRole('option', { name: '山田 一郎' }));
+
+    // 起点 (山田 一郎) の祖先 + 子孫 + 配偶者 (= 太郎/花子/一郎) が残り、佐藤 次郎 は除外される
+    expect(screen.getByRole('button', { name: '山田 太郎' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '山田 花子' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '山田 一郎' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '佐藤 次郎' })).not.toBeInTheDocument();
+
+    // クリアで全員復帰
+    await user.click(screen.getByRole('button', { name: 'クリア' }));
+    expect(screen.getByRole('button', { name: '佐藤 次郎' })).toBeInTheDocument();
   });
 });

--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -1,7 +1,8 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 import React from 'react';
 
-import { exportAsPng, exportAsSvg } from '@/components/familyTree/exportImage';
+import { applyFilter, type FilterCriteria } from '@/components/familyTree/applyFilter';
+import { FamilyTreeFilter } from '@/components/familyTree/FamilyTreeFilter';
 import { FamilyTreeToolbar } from '@/components/familyTree/FamilyTreeToolbar';
 import { LABELS_WIDTH } from '@/components/familyTree/layout/internalTypes';
 import { layoutFamilyTree } from '@/components/familyTree/layoutFamilyTree';
@@ -11,10 +12,10 @@ import { ParentChildEdge } from '@/components/familyTree/ParentChildEdge';
 import { PersonNode } from '@/components/familyTree/PersonNode';
 import { SecondaryMarriageEdge } from '@/components/familyTree/SecondaryMarriageEdge';
 import { SecondaryParentEdge } from '@/components/familyTree/SecondaryParentEdge';
+import { useFamilyTreeExport } from '@/components/familyTree/useFamilyTreeExport';
 import { useWheelZoom } from '@/components/familyTree/useWheelZoom';
 import { PersonDialog } from '@/components/person/PersonDialog';
 import { H2 } from '@/components/ui/H2';
-import { toaster } from '@/components/ui/toaster';
 import { type Person } from '@/schemas/personSchema';
 import { usePeopleStore } from '@/store/personStore';
 import { useRelationStore } from '@/store/relationStore';
@@ -41,11 +42,16 @@ export function FamilyTree(): React.ReactNode {
     () => new Map<string, Person>(people.map((p) => [p.id, p])),
     [people],
   );
+  const [filterCriteria, setFilterCriteria] = React.useState<FilterCriteria | null>(null);
+  const filtered = React.useMemo(
+    () => applyFilter(people, relations, filterCriteria),
+    [people, relations, filterCriteria],
+  );
   const result = React.useMemo<LayoutResult>(() => {
     try {
       return {
         ok: true,
-        layout: layoutFamilyTree(people, relations),
+        layout: layoutFamilyTree(filtered.people, filtered.relations),
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -54,7 +60,7 @@ export function FamilyTree(): React.ReactNode {
         error: message,
       };
     }
-  }, [people, relations]);
+  }, [filtered]);
   const [editingPersonId, setEditingPersonId] = React.useState<string | null>(null);
   const editingPerson = editingPersonId === null
     ? undefined
@@ -67,37 +73,12 @@ export function FamilyTree(): React.ReactNode {
       setEditingPersonId(null);
     }
   }, []);
-  const svgRef = React.useRef<SVGSVGElement>(null);
-  const handleExportSvg = React.useCallback((): void => {
-    if (svgRef.current === null || !result.ok) {
-      return;
-    }
-    exportAsSvg(
-      svgRef.current,
-      result.layout.width,
-      result.layout.height,
-      'family-tree.svg',
-    );
-  }, [result]);
-  const handleExportPng = React.useCallback((): void => {
-    if (svgRef.current === null || !result.ok) {
-      return;
-    }
-    void exportAsPng(
-      svgRef.current,
-      result.layout.width,
-      result.layout.height,
-      'family-tree.png',
-      '#ffffff',
-    ).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      toaster.create({
-        title: 'PNG エクスポートに失敗しました。',
-        description: message,
-        type: 'error',
-      });
-    });
-  }, [result]);
+  const { svgRef, handleExportSvg, handleExportPng } = useFamilyTreeExport(
+    result.ok
+      ? { width: result.layout.width,
+        height: result.layout.height }
+      : null,
+  );
   const [zoomIndex, setZoomIndex] = React.useState(DEFAULT_ZOOM_INDEX);
   const zoom = ZOOM_LEVELS[zoomIndex];
   const handleZoomIn = React.useCallback((): void => {
@@ -146,6 +127,16 @@ export function FamilyTree(): React.ReactNode {
           )
           : null}
       </Flex>
+
+      {people.length > 0
+        ? (
+          <FamilyTreeFilter
+            criteria={filterCriteria}
+            onChange={setFilterCriteria}
+            people={people}
+          />
+        )
+        : null}
 
       {people.length === 0
         ? (

--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -43,9 +43,20 @@ export function FamilyTree(): React.ReactNode {
     [people],
   );
   const [filterCriteria, setFilterCriteria] = React.useState<FilterCriteria | null>(null);
+
+  /*
+   * 起点人物が削除された場合は、その criteria を実効的に無視する。
+   * effect で state を書き換えるとカスケード再レンダリングが発生するため、
+   * 派生値として「現在有効な criteria」を計算して以降の処理で使う。
+   */
+  const effectiveCriteria = filterCriteria !== null
+    && personMap.has(filterCriteria.focusPersonId)
+    ? filterCriteria
+    : null;
+
   const filtered = React.useMemo(
-    () => applyFilter(people, relations, filterCriteria),
-    [people, relations, filterCriteria],
+    () => applyFilter(people, relations, effectiveCriteria),
+    [people, relations, effectiveCriteria],
   );
   const result = React.useMemo<LayoutResult>(() => {
     try {
@@ -131,7 +142,7 @@ export function FamilyTree(): React.ReactNode {
       {people.length > 0
         ? (
           <FamilyTreeFilter
-            criteria={filterCriteria}
+            criteria={effectiveCriteria}
             onChange={setFilterCriteria}
             people={people}
           />

--- a/src/components/familyTree/FamilyTreeFilter.tsx
+++ b/src/components/familyTree/FamilyTreeFilter.tsx
@@ -78,7 +78,7 @@ export function FamilyTreeFilter({ people, criteria, onChange }: Props): React.R
         <Select.HiddenSelect />
 
         <Select.Control>
-          <Select.Trigger>
+          <Select.Trigger aria-label="フィルタの起点人物">
             <Select.ValueText placeholder="起点人物を選択" />
           </Select.Trigger>
 
@@ -115,7 +115,7 @@ export function FamilyTreeFilter({ people, criteria, onChange }: Props): React.R
         <Select.HiddenSelect />
 
         <Select.Control>
-          <Select.Trigger>
+          <Select.Trigger aria-label="フィルタの範囲">
             <Select.ValueText />
           </Select.Trigger>
 

--- a/src/components/familyTree/FamilyTreeFilter.tsx
+++ b/src/components/familyTree/FamilyTreeFilter.tsx
@@ -1,0 +1,157 @@
+import { Button, createListCollection, Flex, Portal, Select } from '@chakra-ui/react';
+import React from 'react';
+
+import { type FilterCriteria, type FilterScope } from '@/components/familyTree/applyFilter';
+import { type Person } from '@/schemas/personSchema';
+
+interface Props {
+  people: Person[];
+  criteria: FilterCriteria | null;
+  onChange: (criteria: FilterCriteria | null) => void;
+}
+
+const SCOPE_OPTIONS: { value: FilterScope;
+  label: string; }[] = [
+  {
+    value: 'both',
+    label: '祖先と子孫',
+  },
+  {
+    value: 'ancestors',
+    label: '祖先のみ',
+  },
+  {
+    value: 'descendants',
+    label: '子孫のみ',
+  },
+];
+
+export function FamilyTreeFilter({ people, criteria, onChange }: Props): React.ReactNode {
+  const personCollection = createListCollection({
+    items: people.map((p) => ({
+      label: `${p.familyName} ${p.givenName}`,
+      value: p.id,
+    })),
+  });
+  const scopeCollection = createListCollection({ items: SCOPE_OPTIONS });
+
+  const handlePersonChange = (value: string[]): void => {
+    if (value.length === 0) {
+      onChange(null);
+      return;
+    }
+    onChange({
+      focusPersonId: value[0],
+      scope: criteria?.scope ?? 'both',
+    });
+  };
+
+  const handleScopeChange = (value: string[]): void => {
+    if (value.length === 0 || criteria === null) {
+      return;
+    }
+    onChange({
+      ...criteria,
+      scope: value[0] as FilterScope,
+    });
+  };
+
+  const handleClear = (): void => {
+    onChange(null);
+  };
+
+  const selectedPerson = criteria === null ? [] : [criteria.focusPersonId];
+  const selectedScope = criteria === null ? ['both'] : [criteria.scope];
+
+  return (
+    <Flex
+      alignItems="center"
+      gap={2}
+    >
+      <Select.Root
+        collection={personCollection}
+        onValueChange={({ value }): void => { handlePersonChange(value); }}
+        size="sm"
+        value={selectedPerson}
+        width="180px"
+      >
+        <Select.HiddenSelect />
+
+        <Select.Control>
+          <Select.Trigger>
+            <Select.ValueText placeholder="起点人物を選択" />
+          </Select.Trigger>
+
+          <Select.IndicatorGroup>
+            <Select.Indicator />
+          </Select.IndicatorGroup>
+        </Select.Control>
+
+        <Portal>
+          <Select.Positioner>
+            <Select.Content zIndex={1500}>
+              {personCollection.items.map((p) => (
+                <Select.Item
+                  item={p}
+                  key={p.value}
+                >
+                  {p.label}
+                  <Select.ItemIndicator />
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Positioner>
+        </Portal>
+      </Select.Root>
+
+      <Select.Root
+        collection={scopeCollection}
+        disabled={criteria === null}
+        onValueChange={({ value }): void => { handleScopeChange(value); }}
+        size="sm"
+        value={selectedScope}
+        width="130px"
+      >
+        <Select.HiddenSelect />
+
+        <Select.Control>
+          <Select.Trigger>
+            <Select.ValueText />
+          </Select.Trigger>
+
+          <Select.IndicatorGroup>
+            <Select.Indicator />
+          </Select.IndicatorGroup>
+        </Select.Control>
+
+        <Portal>
+          <Select.Positioner>
+            <Select.Content zIndex={1500}>
+              {scopeCollection.items.map((s) => (
+                <Select.Item
+                  item={s}
+                  key={s.value}
+                >
+                  {s.label}
+                  <Select.ItemIndicator />
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Positioner>
+        </Portal>
+      </Select.Root>
+
+      {criteria === null
+        ? null
+        : (
+          <Button
+            onClick={handleClear}
+            size="sm"
+            variant="outline"
+          >
+            クリア
+          </Button>
+        )}
+    </Flex>
+  );
+}

--- a/src/components/familyTree/applyFilter.test.ts
+++ b/src/components/familyTree/applyFilter.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyFilter } from '@/components/familyTree/applyFilter';
+import { type Person, Sex } from '@/schemas/personSchema';
+import { type Relation, RelationType } from '@/schemas/relationSchema';
+
+const ID = {
+  GP_FATHER: 'aaaaaaaa-0000-4000-8000-000000000001',
+  GP_MOTHER: 'aaaaaaaa-0000-4000-8000-000000000002',
+  P_FATHER: 'bbbbbbbb-0000-4000-8000-000000000001',
+  P_MOTHER: 'bbbbbbbb-0000-4000-8000-000000000002',
+  ME: 'cccccccc-0000-4000-8000-000000000001',
+  SPOUSE: 'cccccccc-0000-4000-8000-000000000002',
+  CHILD: 'dddddddd-0000-4000-8000-000000000001',
+  OUTSIDER: 'eeeeeeee-0000-4000-8000-000000000001',
+} as const;
+
+function person(id: string): Person {
+  return {
+    id,
+    familyName: '山田',
+    givenName: '名',
+    familyNameKana: 'ヤマダ',
+    givenNameKana: 'ナ',
+    sex: Sex.UNKNOWN,
+    birth: '',
+    death: '',
+  };
+}
+
+function parentRel(id: string, parent: string, child: string): Relation {
+  return {
+    id,
+    relationType: [RelationType.PARENT_CHILD],
+    persons: {
+      personId1: [parent],
+      personId2: [child],
+    },
+  };
+}
+
+function marriedRel(id: string, p1: string, p2: string): Relation {
+  return {
+    id,
+    relationType: [RelationType.MARRIED_COUPLE],
+    persons: {
+      personId1: [p1],
+      personId2: [p2],
+    },
+  };
+}
+
+const people = [
+  person(ID.GP_FATHER),
+  person(ID.GP_MOTHER),
+  person(ID.P_FATHER),
+  person(ID.P_MOTHER),
+  person(ID.ME),
+  person(ID.SPOUSE),
+  person(ID.CHILD),
+  person(ID.OUTSIDER),
+];
+
+const relations: Relation[] = [
+  // 祖父母世代
+  marriedRel('m-gp', ID.GP_FATHER, ID.GP_MOTHER),
+  // 親世代
+  marriedRel('m-p', ID.P_FATHER, ID.P_MOTHER),
+  // 祖父母 → 父
+  parentRel('par-gpf-pf', ID.GP_FATHER, ID.P_FATHER),
+  parentRel('par-gpm-pf', ID.GP_MOTHER, ID.P_FATHER),
+  // 親 → 私
+  parentRel('par-pf-me', ID.P_FATHER, ID.ME),
+  parentRel('par-pm-me', ID.P_MOTHER, ID.ME),
+  // 私と配偶者
+  marriedRel('m-me', ID.ME, ID.SPOUSE),
+  // 私と配偶者 → 子
+  parentRel('par-me-c', ID.ME, ID.CHILD),
+  parentRel('par-s-c', ID.SPOUSE, ID.CHILD),
+];
+
+describe('applyFilter', () => {
+  it('criteria=null なら無加工で返す', () => {
+    const result = applyFilter(people, relations, null);
+    expect(result.people).toHaveLength(8);
+    expect(result.relations).toHaveLength(9);
+  });
+
+  it('scope=ancestors: 起点+祖先+それぞれの配偶者のみ', () => {
+    const result = applyFilter(people, relations, {
+      focusPersonId: ID.ME,
+      scope: 'ancestors',
+    });
+    const ids = result.people.map((p) => p.id).sort();
+    // 起点 = ME, ancestors = P_FATHER, GP_FATHER (経路上). 配偶者として P_MOTHER, GP_MOTHER, SPOUSE
+    expect(ids).toEqual([
+      ID.GP_FATHER,
+      ID.GP_MOTHER,
+      ID.P_FATHER,
+      ID.P_MOTHER,
+      ID.ME,
+      ID.SPOUSE,
+    ].sort());
+    // CHILD と OUTSIDER は含まれない
+    expect(ids).not.toContain(ID.CHILD);
+    expect(ids).not.toContain(ID.OUTSIDER);
+  });
+
+  it('scope=descendants: 起点+子孫+配偶者', () => {
+    const result = applyFilter(people, relations, {
+      focusPersonId: ID.ME,
+      scope: 'descendants',
+    });
+    const ids = result.people.map((p) => p.id).sort();
+    expect(ids).toEqual([ID.ME, ID.SPOUSE, ID.CHILD].sort());
+  });
+
+  it('scope=both: 起点+祖先+子孫+各々の配偶者', () => {
+    const result = applyFilter(people, relations, {
+      focusPersonId: ID.ME,
+      scope: 'both',
+    });
+    const ids = result.people.map((p) => p.id).sort();
+    expect(ids).toContain(ID.GP_FATHER);
+    expect(ids).toContain(ID.ME);
+    expect(ids).toContain(ID.CHILD);
+    expect(ids).not.toContain(ID.OUTSIDER);
+  });
+
+  it('対象 personIds 外を参照する relation は除外される', () => {
+    const result = applyFilter(people, relations, {
+      focusPersonId: ID.ME,
+      scope: 'descendants',
+    });
+    // 祖父母世代の婚姻 (m-gp) は除外、子の親子関係 (par-me-c, par-s-c) と私の婚姻 (m-me) は残る
+    const ids = result.relations.map((r) => r.id).sort();
+    expect(ids).toEqual(['m-me', 'par-me-c', 'par-s-c'].sort());
+  });
+});

--- a/src/components/familyTree/applyFilter.test.ts
+++ b/src/components/familyTree/applyFilter.test.ts
@@ -137,6 +137,25 @@ describe('applyFilter', () => {
     expect(ids).toEqual(['m-me', 'par-me-c', 'par-s-c'].sort());
   });
 
+  it('削除済み人物を経由した辿りでその先の親類を含めない', () => {
+    /*
+     * P_FATHER が削除されたが par-gpf-pf / par-gpm-pf / par-pf-me などの relation は残っている状態。
+     * 起点 = ME で祖先方向に辿るとき、削除済みの P_FATHER を経由して GP_FATHER / GP_MOTHER に
+     * 到達してしまわないことを検証する。
+     */
+    const peopleWithoutFather = people.filter((p) => p.id !== ID.P_FATHER);
+    const result = applyFilter(peopleWithoutFather, relations, {
+      focusPersonId: ID.ME,
+      scope: 'ancestors',
+    });
+    const ids = result.people.map((p) => p.id);
+    expect(ids).not.toContain(ID.GP_FATHER);
+    expect(ids).not.toContain(ID.GP_MOTHER);
+    // 母 (P_MOTHER) と起点 (ME) は残る (P_MOTHER は別経路で繋がっている)
+    expect(ids).toContain(ID.P_MOTHER);
+    expect(ids).toContain(ID.ME);
+  });
+
   it('relations にだけ残っていて people に無い id は filteredRelations に含めない', () => {
     /*
      * 親 (P_FATHER) が削除された状態 (people には居ないが、par-pf-me / par-gpf-pf 等の

--- a/src/components/familyTree/applyFilter.test.ts
+++ b/src/components/familyTree/applyFilter.test.ts
@@ -136,4 +136,24 @@ describe('applyFilter', () => {
     const ids = result.relations.map((r) => r.id).sort();
     expect(ids).toEqual(['m-me', 'par-me-c', 'par-s-c'].sort());
   });
+
+  it('relations にだけ残っていて people に無い id は filteredRelations に含めない', () => {
+    /*
+     * 親 (P_FATHER) が削除された状態 (people には居ないが、par-pf-me / par-gpf-pf 等の
+     * relation には残っている) を模擬する。
+     */
+    const peopleWithoutFather = people.filter((p) => p.id !== ID.P_FATHER);
+    const result = applyFilter(peopleWithoutFather, relations, {
+      focusPersonId: ID.ME,
+      scope: 'ancestors',
+    });
+    // P_FATHER が両端のいずれかになる relation は含まれない
+    const referencesFather = result.relations.some((r) => {
+      return r.persons.personId1[0] === ID.P_FATHER
+        || r.persons.personId2[0] === ID.P_FATHER;
+    });
+    expect(referencesFather).toBe(false);
+    // people 側にも P_FATHER は居ない
+    expect(result.people.some((p) => p.id === ID.P_FATHER)).toBe(false);
+  });
 });

--- a/src/components/familyTree/applyFilter.ts
+++ b/src/components/familyTree/applyFilter.ts
@@ -134,11 +134,19 @@ export function applyFilter(
   }
   addSpouses(collected, maps.spouseMap);
   const filteredPeople = people.filter((p) => collected.has(p.id));
+
+  /*
+   * relation の両端が実在する人物 (filteredPeople) に含まれるものだけ残す。
+   * `collected` は relations から構築した親子グラフ由来なので、削除済み人物の id が
+   * 残るケースがあり、それを基準にすると people / relations が内部的に不整合になる。
+   */
+  const filteredPersonIds = new Set(filteredPeople.map((p) => p.id));
   const filteredRelations = relations.filter((r) => {
     if (r.persons.personId1.length === 0 || r.persons.personId2.length === 0) {
       return false;
     }
-    return collected.has(r.persons.personId1[0]) && collected.has(r.persons.personId2[0]);
+    return filteredPersonIds.has(r.persons.personId1[0])
+      && filteredPersonIds.has(r.persons.personId2[0]);
   });
   return {
     people: filteredPeople,

--- a/src/components/familyTree/applyFilter.ts
+++ b/src/components/familyTree/applyFilter.ts
@@ -1,0 +1,147 @@
+import { type Person } from '@/schemas/personSchema';
+import { type Relation, RelationType } from '@/schemas/relationSchema';
+
+export type FilterScope = 'ancestors' | 'descendants' | 'both';
+
+export interface FilterCriteria {
+  focusPersonId: string;
+  scope: FilterScope;
+}
+
+interface ParentChildMaps {
+  parentToChildren: Map<string, Set<string>>;
+  childToParents: Map<string, Set<string>>;
+  // person → 配偶者 (married-couple / couple)
+  spouseMap: Map<string, Set<string>>;
+}
+
+function buildMaps(relations: Relation[]): ParentChildMaps {
+  const parentToChildren = new Map<string, Set<string>>();
+  const childToParents = new Map<string, Set<string>>();
+  const spouseMap = new Map<string, Set<string>>();
+  for (const rel of relations) {
+    const type = rel.relationType[0];
+    if (rel.persons.personId1.length === 0 || rel.persons.personId2.length === 0) {
+      continue;
+    }
+    const p1 = rel.persons.personId1[0];
+    const p2 = rel.persons.personId2[0];
+    if (type === RelationType.PARENT_CHILD || type === RelationType.PARENT_ADOPTED_CHILD) {
+      const parent = p1;
+      const child = p2;
+      const children = parentToChildren.get(parent) ?? new Set();
+      children.add(child);
+      parentToChildren.set(parent, children);
+      const parents = childToParents.get(child) ?? new Set();
+      parents.add(parent);
+      childToParents.set(child, parents);
+      continue;
+    }
+    if (type === RelationType.MARRIED_COUPLE || type === RelationType.COUPLE) {
+      const s1 = spouseMap.get(p1) ?? new Set();
+      s1.add(p2);
+      spouseMap.set(p1, s1);
+      const s2 = spouseMap.get(p2) ?? new Set();
+      s2.add(p1);
+      spouseMap.set(p2, s2);
+    }
+  }
+  return {
+    parentToChildren,
+    childToParents,
+    spouseMap,
+  };
+}
+
+function collectAncestors(personId: string, maps: ParentChildMaps): Set<string> {
+  const visited = new Set<string>();
+  const queue = [personId];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    const parents = maps.childToParents.get(current) ?? new Set();
+    for (const p of parents) {
+      queue.push(p);
+    }
+  }
+  return visited;
+}
+
+function collectDescendants(personId: string, maps: ParentChildMaps): Set<string> {
+  const visited = new Set<string>();
+  const queue = [personId];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    const children = maps.parentToChildren.get(current) ?? new Set();
+    for (const c of children) {
+      queue.push(c);
+    }
+  }
+  return visited;
+}
+
+function addSpouses(ids: Set<string>, spouseMap: Map<string, Set<string>>): void {
+  /*
+   * 血縁範囲に含まれる各人の配偶者を追加する。
+   * 配偶者の祖先/子孫は辿らない (= 元の血縁範囲だけが対象、配偶者は「並べる相手」として表示)。
+   */
+  const original = Array.from(ids);
+  for (const id of original) {
+    const spouses = spouseMap.get(id);
+    if (spouses === undefined) {
+      continue;
+    }
+    for (const s of spouses) {
+      ids.add(s);
+    }
+  }
+}
+
+export interface FilterResult {
+  people: Person[];
+  relations: Relation[];
+}
+
+export function applyFilter(
+  people: Person[],
+  relations: Relation[],
+  criteria: FilterCriteria | null,
+): FilterResult {
+  if (criteria === null) {
+    return {
+      people,
+      relations,
+    };
+  }
+  const maps = buildMaps(relations);
+  const collected = new Set<string>();
+  if (criteria.scope === 'ancestors' || criteria.scope === 'both') {
+    for (const id of collectAncestors(criteria.focusPersonId, maps)) {
+      collected.add(id);
+    }
+  }
+  if (criteria.scope === 'descendants' || criteria.scope === 'both') {
+    for (const id of collectDescendants(criteria.focusPersonId, maps)) {
+      collected.add(id);
+    }
+  }
+  addSpouses(collected, maps.spouseMap);
+  const filteredPeople = people.filter((p) => collected.has(p.id));
+  const filteredRelations = relations.filter((r) => {
+    if (r.persons.personId1.length === 0 || r.persons.personId2.length === 0) {
+      return false;
+    }
+    return collected.has(r.persons.personId1[0]) && collected.has(r.persons.personId2[0]);
+  });
+  return {
+    people: filteredPeople,
+    relations: filteredRelations,
+  };
+}

--- a/src/components/familyTree/applyFilter.ts
+++ b/src/components/familyTree/applyFilter.ts
@@ -109,18 +109,17 @@ export interface FilterResult {
   relations: Relation[];
 }
 
-export function applyFilter(
-  people: Person[],
-  relations: Relation[],
-  criteria: FilterCriteria | null,
-): FilterResult {
-  if (criteria === null) {
-    return {
-      people,
-      relations,
-    };
+function hasBothEndsIn(rel: Relation, ids: Set<string>): boolean {
+  if (rel.persons.personId1.length === 0 || rel.persons.personId2.length === 0) {
+    return false;
   }
-  const maps = buildMaps(relations);
+  return ids.has(rel.persons.personId1[0]) && ids.has(rel.persons.personId2[0]);
+}
+
+function collectInScope(
+  criteria: FilterCriteria,
+  maps: ParentChildMaps,
+): Set<string> {
   const collected = new Set<string>();
   if (criteria.scope === 'ancestors' || criteria.scope === 'both') {
     for (const id of collectAncestors(criteria.focusPersonId, maps)) {
@@ -133,6 +132,29 @@ export function applyFilter(
     }
   }
   addSpouses(collected, maps.spouseMap);
+  return collected;
+}
+
+export function applyFilter(
+  people: Person[],
+  relations: Relation[],
+  criteria: FilterCriteria | null,
+): FilterResult {
+  if (criteria === null) {
+    return {
+      people,
+      relations,
+    };
+  }
+
+  /*
+   * 削除済み人物を経由した辿りで遠い親類が含まれてしまわないよう、
+   * 両端が people に実在する relation だけで親子グラフを構築する。
+   */
+  const personIds = new Set(people.map((p) => p.id));
+  const validRelations = relations.filter((r) => hasBothEndsIn(r, personIds));
+  const maps = buildMaps(validRelations);
+  const collected = collectInScope(criteria, maps);
   const filteredPeople = people.filter((p) => collected.has(p.id));
 
   /*
@@ -141,13 +163,7 @@ export function applyFilter(
    * 残るケースがあり、それを基準にすると people / relations が内部的に不整合になる。
    */
   const filteredPersonIds = new Set(filteredPeople.map((p) => p.id));
-  const filteredRelations = relations.filter((r) => {
-    if (r.persons.personId1.length === 0 || r.persons.personId2.length === 0) {
-      return false;
-    }
-    return filteredPersonIds.has(r.persons.personId1[0])
-      && filteredPersonIds.has(r.persons.personId2[0]);
-  });
+  const filteredRelations = relations.filter((r) => hasBothEndsIn(r, filteredPersonIds));
   return {
     people: filteredPeople,
     relations: filteredRelations,

--- a/src/components/familyTree/useFamilyTreeExport.ts
+++ b/src/components/familyTree/useFamilyTreeExport.ts
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { exportAsPng, exportAsSvg } from '@/components/familyTree/exportImage';
+import { toaster } from '@/components/ui/toaster';
+
+interface LayoutSize {
+  width: number;
+  height: number;
+}
+
+interface ExportHandlers {
+  svgRef: React.RefObject<SVGSVGElement | null>;
+  handleExportSvg: () => void;
+  handleExportPng: () => void;
+}
+
+/*
+ * FamilyTree の SVG/PNG エクスポート用ハンドラを切り出したフック。
+ * 親コンポーネントの行数制限 (max-lines) を守るため独立させている。
+ */
+export function useFamilyTreeExport(layout: LayoutSize | null): ExportHandlers {
+  const svgRef = React.useRef<SVGSVGElement>(null);
+  const handleExportSvg = React.useCallback((): void => {
+    if (svgRef.current === null || layout === null) {
+      return;
+    }
+    exportAsSvg(svgRef.current, layout.width, layout.height, 'family-tree.svg');
+  }, [layout]);
+  const handleExportPng = React.useCallback((): void => {
+    if (svgRef.current === null || layout === null) {
+      return;
+    }
+    void exportAsPng(
+      svgRef.current,
+      layout.width,
+      layout.height,
+      'family-tree.png',
+      '#ffffff',
+    ).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      toaster.create({
+        title: 'PNG エクスポートに失敗しました。',
+        description: message,
+        type: 'error',
+      });
+    });
+  }, [layout]);
+  return {
+    svgRef,
+    handleExportSvg,
+    handleExportPng,
+  };
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -48,6 +48,14 @@ Object.defineProperty(window, 'ResizeObserver', {
   value: ResizeObserverStub,
 });
 
+/*
+ * jsdom の Element には scrollTo が無いため、Chakra v3 / @zag-js の Select が
+ * ドロップダウン閉じ際に呼び出して例外になる。no-op で stub しておく。
+ */
+if (typeof Element.prototype.scrollTo !== 'function') {
+  Element.prototype.scrollTo = (): void => { /* no-op */ };
+}
+
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION
## Summary
- `applyFilter` (純粋関数) で起点人物の祖先 / 子孫 / 両方を抽出し、配偶者は血縁範囲内なら含める形で people / relations を絞り込む
- `FamilyTreeFilter` コンポーネントを追加: 起点人物 Select + スコープ Select + クリアボタン
- `FamilyTree` でフィルタ state を管理し、レイアウト計算前に絞り込みを適用
- `useFamilyTreeExport` フックを切り出し (FamilyTree.tsx の行数制限対応)

## スコープ外として切り出した課題
- **#147**: ノード操作 (右クリック/長押し等) で起点人物を指定する導線
- **#148**: 兄弟も含めるスコープオプション
- **#149**: 複数フィルタ条件の組み合わせ (AND / OR)

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] `yarn test` (85/85 — applyFilter の 5 ケース追加)
- [x] `yarn build`
- [ ] ブラウザでサンプル読込 → 起点人物を選び祖先/子孫/両方を切り替えて表示が変わることを確認
- [ ] クリアで全員表示に戻ることを確認

Closes #55