### PR TITLE
[#147] PersonDialog から「この人を起点にフィルタ」を追加

### DIFF
--- a/src/components/familyTree/FamilyTree.tsx
+++ b/src/components/familyTree/FamilyTree.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { applyFilter, type FilterCriteria } from '@/components/familyTree/applyFilter';
 import { FamilyTreeFilter } from '@/components/familyTree/FamilyTreeFilter';
 import { FamilyTreeToolbar } from '@/components/familyTree/FamilyTreeToolbar';
-import { LABELS_WIDTH } from '@/components/familyTree/layout/internalTypes';
+import { GenerationLabels } from '@/components/familyTree/GenerationLabels';
 import { layoutFamilyTree } from '@/components/familyTree/layoutFamilyTree';
 import { MarriageEdge } from '@/components/familyTree/MarriageEdge';
 import { Minimap } from '@/components/familyTree/Minimap';
@@ -83,6 +83,13 @@ export function FamilyTree(): React.ReactNode {
     if (!e.open) {
       setEditingPersonId(null);
     }
+  }, []);
+  const handleFilterFocus = React.useCallback((personId: string): void => {
+    setFilterCriteria({
+      focusPersonId: personId,
+      scope: 'both',
+    });
+    setEditingPersonId(null);
   }, []);
   const { svgRef, handleExportSvg, handleExportPng } = useFamilyTreeExport(
     result.ok
@@ -176,36 +183,11 @@ export function FamilyTree(): React.ReactNode {
             ref={containerRef}
           >
             <Flex>
-              <Box
-                bg="bg"
-                flexShrink={0}
-                height={`${(result.layout.height * zoom).toString()}px`}
-                left={0}
-                position="sticky"
-                width={`${LABELS_WIDTH.toString()}px`}
-                zIndex={1}
-              >
-                {result.layout.generationRows.map((row) => (
-                  <Box
-                    alignItems="center"
-                    display="flex"
-                    height={`${(row.height * zoom).toString()}px`}
-                    justifyContent="center"
-                    key={row.y}
-                    left={0}
-                    position="absolute"
-                    top={`${(row.y * zoom).toString()}px`}
-                    width="100%"
-                  >
-                    <Text
-                      color="fg.muted"
-                      fontSize="xs"
-                    >
-                      {`第${(row.generation + 1).toString()}世代`}
-                    </Text>
-                  </Box>
-                ))}
-              </Box>
+              <GenerationLabels
+                rows={result.layout.generationRows}
+                totalHeight={result.layout.height}
+                zoom={zoom}
+              />
 
               <Box flexShrink={0}>
                 <svg
@@ -286,6 +268,7 @@ export function FamilyTree(): React.ReactNode {
           <PersonDialog
             isOpen
             key={editingPerson.id}
+            onFilterFocus={handleFilterFocus}
             onOpenChange={handleDialogOpenChange}
             person={editingPerson}
           />

--- a/src/components/familyTree/GenerationLabels.tsx
+++ b/src/components/familyTree/GenerationLabels.tsx
@@ -1,0 +1,49 @@
+import { Box, Text } from '@chakra-ui/react';
+import React from 'react';
+
+import { LABELS_WIDTH } from '@/components/familyTree/layout/internalTypes';
+import { type GenerationRowLayout } from '@/components/familyTree/types';
+
+interface Props {
+  rows: GenerationRowLayout[];
+  totalHeight: number;
+  zoom: number;
+}
+
+/*
+ * 世代ラベルの縦帯。左端に sticky で配置され、世代ごとに「第N世代」と表示する。
+ */
+export function GenerationLabels({ rows, totalHeight, zoom }: Props): React.ReactNode {
+  return (
+    <Box
+      bg="bg"
+      flexShrink={0}
+      height={`${(totalHeight * zoom).toString()}px`}
+      left={0}
+      position="sticky"
+      width={`${LABELS_WIDTH.toString()}px`}
+      zIndex={1}
+    >
+      {rows.map((row) => (
+        <Box
+          alignItems="center"
+          display="flex"
+          height={`${(row.height * zoom).toString()}px`}
+          justifyContent="center"
+          key={row.y}
+          left={0}
+          position="absolute"
+          top={`${(row.y * zoom).toString()}px`}
+          width="100%"
+        >
+          <Text
+            color="fg.muted"
+            fontSize="xs"
+          >
+            {`第${(row.generation + 1).toString()}世代`}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/src/components/person/PersonDialog.test.tsx
+++ b/src/components/person/PersonDialog.test.tsx
@@ -134,4 +134,53 @@ describe('PersonDialog', () => {
     await user.click(screen.getByRole('button', { name: '保存' }));
     expect(usePeopleStore.getState().people[0].maidenName).toBe('佐藤');
   });
+
+  it('編集モードで onFilterFocus が指定されていると「起点にする」ボタンが出る', () => {
+    renderWithProvider(
+      <PersonDialog
+        isOpen
+        onFilterFocus={vi.fn()}
+        onOpenChange={vi.fn()}
+        person={makePerson()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'この人を起点にフィルタ' })).toBeInTheDocument();
+  });
+
+  it('onFilterFocus 未指定なら「起点にする」ボタンは出ない', () => {
+    renderWithProvider(
+      <PersonDialog
+        isOpen
+        onOpenChange={vi.fn()}
+        person={makePerson()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'この人を起点にフィルタ' })).not.toBeInTheDocument();
+  });
+
+  it('「起点にする」を押すと onFilterFocus が person.id 付きで呼ばれる', async() => {
+    const user = userEvent.setup();
+    const onFilterFocus = vi.fn();
+    renderWithProvider(
+      <PersonDialog
+        isOpen
+        onFilterFocus={onFilterFocus}
+        onOpenChange={vi.fn()}
+        person={makePerson()}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'この人を起点にフィルタ' }));
+    expect(onFilterFocus).toHaveBeenCalledExactlyOnceWith(ID);
+  });
+
+  it('新規追加モード (person 未指定) では「起点にする」ボタンは出ない', () => {
+    renderWithProvider(
+      <PersonDialog
+        isOpen
+        onFilterFocus={vi.fn()}
+        onOpenChange={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'この人を起点にフィルタ' })).not.toBeInTheDocument();
+  });
 });

--- a/src/components/person/PersonDialog.tsx
+++ b/src/components/person/PersonDialog.tsx
@@ -13,6 +13,7 @@ interface PersonDialogProps {
   isOpen: boolean;
   onOpenChange: (e: { open: boolean }) => void;
   person?: Person;
+  onFilterFocus?: (personId: string) => void;
 }
 
 function buildDefaultValues(person: Person | undefined): Person {
@@ -33,7 +34,7 @@ function buildDefaultValues(person: Person | undefined): Person {
   };
 }
 
-export function PersonDialog({ isOpen, onOpenChange, person }: PersonDialogProps): React.ReactNode {
+export function PersonDialog({ isOpen, onOpenChange, person, onFilterFocus }: PersonDialogProps): React.ReactNode {
   const addPerson = usePeopleStore((state) => state.addPerson);
   const updatePerson = usePeopleStore((state) => state.updatePerson);
   const deletePerson = usePeopleStore((state) => state.deletePerson);
@@ -240,6 +241,18 @@ export function PersonDialog({ isOpen, onOpenChange, person }: PersonDialogProps
                       variant="outline"
                     >
                       削除
+                    </Button>
+                  )
+                  : null}
+
+                {isEdit && onFilterFocus !== undefined
+                  ? (
+                    <Button
+                      onClick={(): void => { onFilterFocus(person.id); }}
+                      type="button"
+                      variant="outline"
+                    >
+                      この人を起点にフィルタ
                     </Button>
                   )
                   : null}


### PR DESCRIPTION
## Summary
- `PersonDialog` に `onFilterFocus?: (personId: string) => void` prop を追加
- 編集モード時 (person 指定 + onFilterFocus 指定) のみフッタに「この人を起点にフィルタ」ボタンを表示
- ボタンクリックで `person.id` 付きで callback を呼ぶ
- `FamilyTree` から callback を渡し、起点設定 (scope=both) + dialog を閉じる挙動を実装
- 副次: `FamilyTree.tsx` の行数制限対応で世代ラベル帯を `GenerationLabels` コンポーネントに切り出し

## UX 設計の補足
issue で提示された 2 案 (コンテキストメニュー / Dialog ボタン) のうち **Dialog ボタン** を採用。理由:
- click は既に編集を担う (右クリックを使うとブラウザのコンテキストメニューと衝突しがち)
- Dialog は人物固有のアクションを置くのに自然な場所
- モバイルでも特別な操作なしに動く

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] `yarn test` (92/92 — PersonDialog の起点ボタン関連 4 ケース追加)
- [x] `yarn build`
- [ ] ブラウザでサンプル読込 → 任意のノードをクリック → PersonDialog の「この人を起点にフィルタ」を押すと、フィルタが起点=その人、スコープ=両方 になり Dialog が閉じることを確認

Closes #147