### PR TITLE
[#148] フィルタに「兄弟も含める」オプションを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,4 @@
 - CSS Grid `1fr` はコンテンツ幅に拡張される。内側で `overflowX:auto` したい時は `templateColumns="repeat(N, minmax(0, 1fr))"` にする
 - Flex 子の SVG は `flex-shrink: 1` で縮む。横スクロールを効かせたい時は SVG を `<Box flexShrink={0}>` でラップする
 - Chakra v3 の `<Button>` デフォルトはテキストが見えづらいことがある。既存の `PrimaryButton` を使うか variant を明示する
+- Chakra v3 の `<Checkbox.Control>` は未チェック時の枠線が薄く存在に気づきにくい。`variant="outline"` + `borderColor="border.emphasized"` / `borderWidth="1px"` を明示する

--- a/src/components/familyTree/FamilyTreeFilter.tsx
+++ b/src/components/familyTree/FamilyTreeFilter.tsx
@@ -158,9 +158,16 @@ export function FamilyTreeFilter({ people, criteria, onChange }: Props): React.R
             checked={criteria.includeSiblings === true}
             onCheckedChange={(e): void => { handleSiblingsChange(e.checked === true); }}
             size="sm"
+            variant="outline"
           >
             <Checkbox.HiddenInput />
-            <Checkbox.Control />
+
+            {/* 未チェック時も枠が見えるよう明示的に border を指定する (Chakra v3 の既定だと薄い) */}
+            <Checkbox.Control
+              borderColor="border.emphasized"
+              borderWidth="1px"
+            />
+
             <Checkbox.Label>兄弟も含める</Checkbox.Label>
           </Checkbox.Root>
         )}

--- a/src/components/familyTree/FamilyTreeFilter.tsx
+++ b/src/components/familyTree/FamilyTreeFilter.tsx
@@ -1,4 +1,4 @@
-import { Button, createListCollection, Flex, Portal, Select } from '@chakra-ui/react';
+import { Button, Checkbox, createListCollection, Flex, Portal, Select } from '@chakra-ui/react';
 import React from 'react';
 
 import { type FilterCriteria, type FilterScope } from '@/components/familyTree/applyFilter';
@@ -53,6 +53,16 @@ export function FamilyTreeFilter({ people, criteria, onChange }: Props): React.R
     onChange({
       ...criteria,
       scope: value[0] as FilterScope,
+    });
+  };
+
+  const handleSiblingsChange = (checked: boolean): void => {
+    if (criteria === null) {
+      return;
+    }
+    onChange({
+      ...criteria,
+      includeSiblings: checked,
     });
   };
 
@@ -140,6 +150,20 @@ export function FamilyTreeFilter({ people, criteria, onChange }: Props): React.R
           </Select.Positioner>
         </Portal>
       </Select.Root>
+
+      {criteria === null
+        ? null
+        : (
+          <Checkbox.Root
+            checked={criteria.includeSiblings === true}
+            onCheckedChange={(e): void => { handleSiblingsChange(e.checked === true); }}
+            size="sm"
+          >
+            <Checkbox.HiddenInput />
+            <Checkbox.Control />
+            <Checkbox.Label>兄弟も含める</Checkbox.Label>
+          </Checkbox.Root>
+        )}
 
       {criteria === null
         ? null

--- a/src/components/familyTree/applyFilter.test.ts
+++ b/src/components/familyTree/applyFilter.test.ts
@@ -175,4 +175,55 @@ describe('applyFilter', () => {
     // people 側にも P_FATHER は居ない
     expect(result.people.some((p) => p.id === ID.P_FATHER)).toBe(false);
   });
+
+  describe('includeSiblings', () => {
+    const SIBLING = 'ffffffff-0000-4000-8000-000000000001';
+    const SIBLING_SPOUSE = 'ffffffff-0000-4000-8000-000000000002';
+    const siblingPeople = [...people, person(SIBLING), person(SIBLING_SPOUSE)];
+    const siblingRelations: Relation[] = [
+      ...relations,
+      // 親 → 兄弟 (ME と同じ親)
+      parentRel('par-pf-sib', ID.P_FATHER, SIBLING),
+      parentRel('par-pm-sib', ID.P_MOTHER, SIBLING),
+      // 兄弟の配偶者
+      marriedRel('m-sib', SIBLING, SIBLING_SPOUSE),
+    ];
+
+    it('includeSiblings 未指定なら兄弟は含まれない', () => {
+      const result = applyFilter(siblingPeople, siblingRelations, {
+        focusPersonId: ID.ME,
+        scope: 'ancestors',
+      });
+      expect(result.people.map((p) => p.id)).not.toContain(SIBLING);
+    });
+
+    it('includeSiblings=true で兄弟とその配偶者が含まれる', () => {
+      const result = applyFilter(siblingPeople, siblingRelations, {
+        focusPersonId: ID.ME,
+        scope: 'ancestors',
+        includeSiblings: true,
+      });
+      const ids = result.people.map((p) => p.id);
+      expect(ids).toContain(SIBLING);
+      expect(ids).toContain(SIBLING_SPOUSE);
+    });
+
+    it('兄弟の子孫までは辿らない', () => {
+      const SIBLING_CHILD = 'ffffffff-0000-4000-8000-000000000003';
+      const peopleWithNephew = [...siblingPeople, person(SIBLING_CHILD)];
+      const relationsWithNephew: Relation[] = [
+        ...siblingRelations,
+        parentRel('par-sib-c', SIBLING, SIBLING_CHILD),
+      ];
+      const result = applyFilter(peopleWithNephew, relationsWithNephew, {
+        focusPersonId: ID.ME,
+        scope: 'ancestors',
+        includeSiblings: true,
+      });
+      const ids = result.people.map((p) => p.id);
+      expect(ids).toContain(SIBLING);
+      // 甥/姪 (兄弟の子) は含めない
+      expect(ids).not.toContain(SIBLING_CHILD);
+    });
+  });
 });

--- a/src/components/familyTree/applyFilter.ts
+++ b/src/components/familyTree/applyFilter.ts
@@ -6,6 +6,8 @@ export type FilterScope = 'ancestors' | 'descendants' | 'both';
 export interface FilterCriteria {
   focusPersonId: string;
   scope: FilterScope;
+  // 起点の兄弟姉妹 (直系親の他の子) も含めるか
+  includeSiblings?: boolean;
 }
 
 interface ParentChildMaps {
@@ -116,6 +118,24 @@ function hasBothEndsIn(rel: Relation, ids: Set<string>): boolean {
   return ids.has(rel.persons.personId1[0]) && ids.has(rel.persons.personId2[0]);
 }
 
+/*
+ * 起点の兄弟姉妹 = 起点の直系親 (childToParents) の他の子。起点自身は除く。
+ * 兄弟の子孫までは辿らず「並べる相手」として 1 段だけ含める。
+ */
+function collectSiblings(personId: string, maps: ParentChildMaps): Set<string> {
+  const siblings = new Set<string>();
+  const parents = maps.childToParents.get(personId) ?? new Set();
+  for (const parent of parents) {
+    const children = maps.parentToChildren.get(parent) ?? new Set();
+    for (const child of children) {
+      if (child !== personId) {
+        siblings.add(child);
+      }
+    }
+  }
+  return siblings;
+}
+
 function collectInScope(
   criteria: FilterCriteria,
   maps: ParentChildMaps,
@@ -128,6 +148,11 @@ function collectInScope(
   }
   if (criteria.scope === 'descendants' || criteria.scope === 'both') {
     for (const id of collectDescendants(criteria.focusPersonId, maps)) {
+      collected.add(id);
+    }
+  }
+  if (criteria.includeSiblings === true) {
+    for (const id of collectSiblings(criteria.focusPersonId, maps)) {
       collected.add(id);
     }
   }

--- a/src/components/relation/AddRelationDialog.tsx
+++ b/src/components/relation/AddRelationDialog.tsx
@@ -251,9 +251,16 @@ export function AddRelationDialog({ isOpen, onOpenChange }: AddRelationDialogPro
                                     onCheckedChange={(e): void => {
                                       field.onChange(e.checked === true);
                                     }}
+                                    variant="outline"
                                   >
                                     <Checkbox.HiddenInput onBlur={field.onBlur} />
-                                    <Checkbox.Control />
+
+                                    {/* 未チェック時も枠が見えるよう明示的に border を指定する */}
+                                    <Checkbox.Control
+                                      borderColor="border.emphasized"
+                                      borderWidth="1px"
+                                    />
+
                                     <Checkbox.Label>離婚済み</Checkbox.Label>
                                   </Checkbox.Root>
                                 )}


### PR DESCRIPTION
## Summary
- `FilterCriteria` に optional `includeSiblings: boolean` を追加
- `applyFilter` で起点の直系親の他の子 (= 兄弟姉妹) を収集するロジックを追加
- 兄弟の配偶者は含めるが、兄弟の子孫 (甥/姪) までは辿らない (「並べる相手」として 1 段だけ)
- `FamilyTreeFilter` にフィルタ有効時のみ表示される「兄弟も含める」チェックボックスを追加

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] `yarn test` (95/95 — applyFilter の兄弟ケース 3 件追加)
- [x] `yarn build`
- [ ] ブラウザでサンプル読込 → 起点人物を選び「兄弟も含める」を ON にすると、起点の兄弟姉妹が表示に加わることを確認

Closes #148