### PR TITLE
[#134] Playwright で E2E テストを追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,48 @@
+name: E2E
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      # .yarnrc.yml の enableScripts: false により Playwright のブラウザは
+      # 自動ダウンロードされないため、明示的に install する (システム依存込み)。
+      - name: Install Playwright browser
+        run: yarn playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: yarn e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
 # Editor directories and files
 .idea
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,11 @@
 - `@typescript-eslint/no-unnecessary-condition`: 型上 undefined にならないチェックは無効。`noUncheckedIndexedAccess` が off なので `arr[0]` は `T` 型 → 配列の length チェックで防御する
 - `max-lines-per-function: 50` は `.ts` のみ (`.tsx` とテストファイル `.test.ts` は対象外)。長い関数は小さなヘルパに分割
 
+### テスト
+- ユニット/コンポーネントテストは Vitest (`yarn test`、jsdom)、ページ全体の E2E は Playwright (`yarn e2e`)。Vitest の `include` は `src/**/*.test.{ts,tsx}` に絞ってあり、`e2e/*.spec.ts` は拾わない (両者の `test`/`expect` import 元が違うので混ざると壊れる)
+- Playwright のブラウザは `enableScripts: false` のため `yarn install` で自動取得されない。`yarn playwright install chromium` を手動実行する。CI は `--with-deps` でシステムライブラリも入れる
+- e2e は `tsconfig.app.json` の対象外。型解決のため `tsconfig.e2e.json` を用意し eslint の `parserOptions.project` にも追加してある
+
 ### CSS / レイアウト
 - `<input type="file">` の change イベントは同じファイルを再選択しても発火しない。click 前に `inputRef.current.value = ''` でリセットする
 - CSS Grid `1fr` はコンテンツ幅に拡張される。内側で `overflowX:auto` したい時は `templateColumns="repeat(N, minmax(0, 1fr))"` にする

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ yarn dev
 > [!NOTE]
 > 仕組みは `git config core.hooksPath .githooks` (リポジトリローカル)。**この設定が有効な間は `.git/hooks/*` に置いた既存フックは実行されない**ので、すでに別のフックを使っている場合は注意。元に戻すには `git config --unset core.hooksPath` を実行する。
 
+### E2E テスト (Playwright)
+
+ページ全体の E2E テストは Playwright で実行する (`yarn e2e`)。
+
+```bash
+yarn playwright install chromium   # 初回のみ。ブラウザを取得
+yarn e2e
+```
+
+> [!NOTE]
+> `.yarnrc.yml` の `enableScripts: false` によりブラウザは `yarn install` 時に自動取得されないため、上記の `yarn playwright install` を手動で実行する。Linux でブラウザ起動に必要なシステムライブラリが足りない場合は `yarn playwright install --with-deps chromium` (要 sudo) を使う。
+
 ## ドキュメント
 
 - [docs/family-tree.md](docs/family-tree.md) — 家系図の表記ルール

--- a/e2e/family-tree.spec.ts
+++ b/e2e/family-tree.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const SAMPLE_PATH = fileURLToPath(new URL('../sample/family-tree.json', import.meta.url));
+
+test.beforeEach(async({ page }) => {
+  await page.goto('/');
+});
+
+test('初期状態では家系図に案内メッセージが出る', async({ page }) => {
+  await expect(page.getByText('人物を追加すると家系図が表示されます。')).toBeVisible();
+});
+
+test('サンプル JSON をインポートすると家系図が描画される', async({ page }) => {
+  await page.locator('input[type="file"]').setInputFiles(SAMPLE_PATH);
+  // 家系図 SVG に主要人物のノードが出る
+  await expect(page.getByRole('button', { name: '山田 太郎' })).toBeVisible();
+  await expect(page.getByText('人物を追加すると家系図が表示されます。')).toBeHidden();
+});
+
+test('人物を追加すると人物一覧と家系図に反映される', async({ page }) => {
+  await page.getByRole('button', { name: '人物追加' }).click();
+  // ダイアログのフォーム入力 (姓 / 名 が必須)
+  await page.getByPlaceholder('姓', { exact: true }).fill('テスト');
+  await page.getByPlaceholder('名', { exact: true }).fill('太郎');
+  await page.getByPlaceholder('姓（カナ）').fill('テスト');
+  await page.getByPlaceholder('名（カナ）').fill('タロウ');
+  await page.getByRole('button', { name: '保存' }).click();
+  // 家系図ノードとして描画される
+  await expect(page.getByRole('button', { name: 'テスト 太郎' })).toBeVisible();
+});
+
+test('エクスポートリンクが download 属性付きで存在する', async({ page }) => {
+  const exportLink = page.getByRole('link', { name: 'エクスポート' });
+  await expect(exportLink).toHaveAttribute('download', 'family-tree.json');
+});
+
+test('インポート後にノードをクリックすると編集ダイアログが開く', async({ page }) => {
+  await page.locator('input[type="file"]').setInputFiles(SAMPLE_PATH);
+  await page.getByRole('button', { name: '山田 太郎' }).click();
+  await expect(page.getByText('人物編集')).toBeVisible();
+  await expect(page.getByPlaceholder('姓', { exact: true })).toHaveValue('山田');
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ export default tseslint.config(
       ecmaVersion: 2020,
       globals: globals.browser,
       parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        project: ['./tsconfig.node.json', './tsconfig.app.json', './tsconfig.e2e.json'],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "e2e": "playwright test",
     "hooks:install": "git config core.hooksPath .githooks"
   },
   "dependencies": {
@@ -30,11 +31,13 @@
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",
     "@eslint/js": "~9.39.4",
+    "@playwright/test": "^1.60.0",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.9.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^6.0.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 4173;
+const BASE_URL = `http://localhost:${PORT.toString()}`;
+
+/*
+ * E2E 設定。VRT (スクリーンショット比較) は baseline 戦略の検討が必要なため #154 で別途対応。
+ * webServer は本番ビルドを preview で配信する (dev サーバより挙動が本番に近い)。
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI === undefined ? 0 : 2,
+  reporter: process.env.CI === undefined
+    ? 'list'
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'yarn build && yarn preview --port 4173 --strictPort',
+    url: BASE_URL,
+    reuseExistingServer: process.env.CI === undefined,
+    timeout: 120_000,
+  },
+});

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["e2e", "playwright.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,5 +14,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: false,
     setupFiles: ['./src/test/setup.ts'],
+    // vitest は src 配下のみ対象。Playwright の e2e/*.spec.ts は拾わない。
+    include: ['src/**/*.test.{ts,tsx}'],
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,6 +1232,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
+  dependencies:
+    playwright: "npm:1.60.0"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/86b06e6437933e741c7cd43f362024e857e7bc28a55fcbb0553ef55e01a2a403c64f4786868de8af86a6e303fe99e98a18a42ba19489f43ae122e457f9e2d189
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm64@npm:1.0.1":
   version: 1.0.1
   resolution: "@rolldown/binding-android-arm64@npm:1.0.1"
@@ -1506,6 +1517,15 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^25.9.1":
+  version: 25.9.1
+  resolution: "@types/node@npm:25.9.1"
+  dependencies:
+    undici-types: "npm:>=7.24.0 <7.24.7"
+  checksum: 10c0/9a04682842bebbcf21a1779dfeab9aa733d7bd7bbc0a0edb641ab3a9a3d43eac543225acf669c334f458f1956443ebc072bc3c72840c543b8b356cab5c82d456
   languageName: node
   linkType: hard
 
@@ -3839,11 +3859,13 @@ __metadata:
     "@emotion/react": "npm:^11.14.0"
     "@eslint/js": "npm:~9.39.4"
     "@hookform/resolvers": "npm:^4.1.3"
+    "@playwright/test": "npm:^1.60.0"
     "@stylistic/eslint-plugin": "npm:^5.10.0"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"
     "@testing-library/user-event": "npm:^14.6.1"
+    "@types/node": "npm:^25.9.1"
     "@types/react": "npm:^19.0.10"
     "@types/react-dom": "npm:^19.0.4"
     "@vitejs/plugin-react": "npm:^6.0.2"
@@ -3990,12 +4012,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -5498,6 +5539,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/99ccd43923b6e9355e0723b7fe221e6326efd4687f8dafff951313662aea11db51f542a9c2122c704c445fb9baae1c9ec9fa6f895126bbddd9fe92313f6942c9
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -6462,6 +6527,13 @@ __metadata:
     has-symbols: "npm:^1.1.0"
     which-boxed-primitive: "npm:^1.1.1"
   checksum: 10c0/7dbd35ab02b0e05fe07136c72cb9355091242455473ec15057c11430129bab38b7b3624019b8778d02a881c13de44d63cd02d122ee782fb519e1de7775b5b982
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:>=7.24.0 <7.24.7":
+  version: 7.24.6
+  resolution: "undici-types@npm:7.24.6"
+  checksum: 10c0/d9cd8befb643ac904615c280a095ba4240531f6bb4a5e75a22a7483630ca8d3f1016d2ab6ace6ceda1f63b3a2db2fe037fafe121d6917a0187573aa548ff78ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- `@playwright/test` を導入し `playwright.config.ts` を作成 (chromium / webServer は `build` + `preview` で本番ビルドを配信)
- 主要フローの E2E テスト 5 ケースを追加:
  - サンプル JSON インポート → 家系図描画
  - 人物追加 → 家系図ノードに反映
  - エクスポートリンクの download 属性
  - ノードクリック → 編集ダイアログ
  - 初期状態の案内メッセージ
- E2E CI ワークフロー (`.github/workflows/e2e.yml`) を追加。PR ごとに実行、失敗時は report を artifact 化
- `vitest` の include を `src` 配下に絞り、Playwright の `e2e/*.spec.ts` と混ざらないように分離
- `tsconfig.e2e.json` を追加し eslint の型解決に登録

## VRT は別 issue
スクリーンショット VRT は baseline の OS 差戦略が必要なため **#154** に切り出し済み。本 PR は E2E のみ。

## サプライチェーン
- `@playwright/test` は公式 (Microsoft)。`actions/upload-artifact` は SHA pin (v4.6.2)
- `enableScripts: false` によりブラウザは自動 DL されないため、CI は `yarn playwright install --with-deps chromium` で明示取得

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit` / `tsconfig.e2e.json`
- [x] `yarn test` (95/95 — vitest は従来通り)
- [x] `yarn build`
- [x] `yarn e2e` (5/5 passed — ローカルで chromium 実走確認)
- [x] CI の E2E ジョブが green になること

Closes #134