### PR TITLE
[#154] Playwright VRT (ビジュアルリグレッションテスト) を追加

### DIFF
--- a/.github/workflows/vrt-run.yml
+++ b/.github/workflows/vrt-run.yml
@@ -67,6 +67,8 @@ jobs:
           name: vrt-report
           path: playwright-report/
           retention-days: 7
+          # 依存インストール失敗等で report 未生成のとき、二次的な path not found を避ける
+          if-no-files-found: ignore
 
       - name: Upload baselines
         if: ${{ inputs.update-snapshots }}
@@ -75,3 +77,5 @@ jobs:
           name: vrt-baselines
           path: e2e/__screenshots__/
           retention-days: 7
+          # 生成途中で失敗し screenshots 未作成のとき、二次的な path not found を避ける
+          if-no-files-found: ignore

--- a/.github/workflows/vrt-run.yml
+++ b/.github/workflows/vrt-run.yml
@@ -22,6 +22,8 @@ jobs:
     # @playwright/test と一致していることを起動前に保証する。
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
+      # フォント追加 (apt-get) に root が要るため、イメージの既定ユーザーに依存せず明示する
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/vrt-run.yml
+++ b/.github/workflows/vrt-run.yml
@@ -1,0 +1,74 @@
+name: VRT Run (reusable)
+
+# VRT の実行手順を集約した再利用ワークフロー。
+# - 比較 (vrt.yml) と baseline 生成 (vrt-update.yml) で同一のイメージ・手順を使う
+# - Playwright のイメージタグは PLAYWRIGHT_IMAGE に 1 箇所だけ定義する
+on:
+  workflow_call:
+    inputs:
+      update-snapshots:
+        description: baseline を生成する場合 true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  vrt:
+    runs-on: ubuntu-latest
+    # Playwright のイメージタグはこの 1 箇所だけ。下のバージョン検証で
+    # @playwright/test と一致していることを起動前に保証する。
+    container:
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      # コンテナ内蔵ブラウザは @playwright/test のバージョンに対応している必要がある。
+      # ずれると「ブラウザが見つからない」系で壊れるため、コンテナ同梱の Playwright (PATH 上の
+      # グローバル) とプロジェクトの版を直接突き合わせて起動前に検証する。
+      - name: Verify Playwright version matches image
+        run: |
+          IMAGE_VERSION="$(playwright --version | awk '{print $2}')"
+          PROJECT_VERSION="$(yarn playwright --version | awk '{print $2}')"
+          echo "image=${IMAGE_VERSION} project=${PROJECT_VERSION}"
+          if [ "${IMAGE_VERSION}" != "${PROJECT_VERSION}" ]; then
+            echo "::error::Playwright のバージョン不一致: image=${IMAGE_VERSION} / @playwright/test=${PROJECT_VERSION}。vrt-run.yml の container.image と package.json を揃えてください"
+            exit 1
+          fi
+
+      - name: Install CJK fonts
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends fonts-noto-cjk
+
+      - name: Run VRT (compare)
+        if: ${{ !inputs.update-snapshots }}
+        run: yarn vrt
+
+      - name: Run VRT (update baselines)
+        if: ${{ inputs.update-snapshots }}
+        run: yarn vrt --update-snapshots
+
+      - name: Upload VRT report
+        if: ${{ !inputs.update-snapshots && !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vrt-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload baselines
+        if: ${{ inputs.update-snapshots }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vrt-baselines
+          path: e2e/__screenshots__/
+          retention-days: 7

--- a/.github/workflows/vrt-run.yml
+++ b/.github/workflows/vrt-run.yml
@@ -2,7 +2,8 @@ name: VRT Run (reusable)
 
 # VRT の実行手順を集約した再利用ワークフロー。
 # - 比較 (vrt.yml) と baseline 生成 (vrt-update.yml) で同一のイメージ・手順を使う
-# - Playwright のイメージタグは PLAYWRIGHT_IMAGE に 1 箇所だけ定義する
+# - Playwright のイメージタグは下の jobs.vrt.container.image に 1 箇所だけ書く
+#   (@playwright/test との一致は "Verify Playwright version matches image" で検証)
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/vrt-run.yml
+++ b/.github/workflows/vrt-run.yml
@@ -53,15 +53,15 @@ jobs:
           apt-get install -y --no-install-recommends fonts-noto-cjk
 
       - name: Run VRT (compare)
-        if: ${{ !inputs.update-snapshots }}
+        if: ${{ !inputs['update-snapshots'] }}
         run: yarn vrt
 
       - name: Run VRT (update baselines)
-        if: ${{ inputs.update-snapshots }}
+        if: ${{ inputs['update-snapshots'] }}
         run: yarn vrt --update-snapshots
 
       - name: Upload VRT report
-        if: ${{ !inputs.update-snapshots && !cancelled() }}
+        if: ${{ !inputs['update-snapshots'] && !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vrt-report
@@ -71,7 +71,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload baselines
-        if: ${{ inputs.update-snapshots }}
+        if: ${{ inputs['update-snapshots'] }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vrt-baselines

--- a/.github/workflows/vrt-update.yml
+++ b/.github/workflows/vrt-update.yml
@@ -1,0 +1,40 @@
+name: VRT Update Baselines
+
+# 手動実行専用。baseline スクリーンショットを生成し artifact としてアップロードする。
+# ダウンロードして e2e/__screenshots__/ に展開・commit する運用。
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    # vrt.yml の比較ジョブと完全に同一イメージ・同一フォントで生成する。
+    container:
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install CJK fonts
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends fonts-noto-cjk
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Generate baselines
+        run: yarn vrt --update-snapshots
+
+      - name: Upload baselines
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vrt-baselines
+          path: e2e/__screenshots__/
+          retention-days: 7

--- a/.github/workflows/vrt-update.yml
+++ b/.github/workflows/vrt-update.yml
@@ -10,31 +10,6 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
-    # vrt.yml の比較ジョブと完全に同一イメージ・同一フォントで生成する。
-    container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install CJK fonts
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends fonts-noto-cjk
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Generate baselines
-        run: yarn vrt --update-snapshots
-
-      - name: Upload baselines
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: vrt-baselines
-          path: e2e/__screenshots__/
-          retention-days: 7
+    uses: ./.github/workflows/vrt-run.yml
+    with:
+      update-snapshots: true

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -1,10 +1,10 @@
 name: VRT
 
+# baseline を別 PR で投入する運用のため、投入が完了するまで push (= main) トリガーは
+# 付けない。baseline 不在のまま main で走ると default ブランチが常に赤になるのを避ける。
+# baseline 投入後に push: branches: [main] を追加する。
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -1,0 +1,47 @@
+name: VRT
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vrt-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vrt:
+    runs-on: ubuntu-latest
+    # baseline 生成 (vrt-update) と同一イメージで実行し、フォント差で誤検知しないようにする。
+    container:
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # 日本語が豆腐にならないよう CJK フォントを入れる (baseline 生成側と必ず揃える)。
+      - name: Install CJK fonts
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends fonts-noto-cjk
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run VRT
+        run: yarn vrt
+
+      - name: Upload VRT report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vrt-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -14,34 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  vrt:
-    runs-on: ubuntu-latest
-    # baseline 生成 (vrt-update) と同一イメージで実行し、フォント差で誤検知しないようにする。
-    container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      # 日本語が豆腐にならないよう CJK フォントを入れる (baseline 生成側と必ず揃える)。
-      - name: Install CJK fonts
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends fonts-noto-cjk
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Run VRT
-        run: yarn vrt
-
-      - name: Upload VRT report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: vrt-report
-          path: playwright-report/
-          retention-days: 7
+  compare:
+    uses: ./.github/workflows/vrt-run.yml
+    with:
+      update-snapshots: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@
 - ユニット/コンポーネントテストは Vitest (`yarn test`、jsdom)、ページ全体の E2E は Playwright (`yarn e2e`)。Vitest の `include` は `src/**/*.test.{ts,tsx}` に絞ってあり、`e2e/*.spec.ts` は拾わない (両者の `test`/`expect` import 元が違うので混ざると壊れる)
 - Playwright のブラウザは `enableScripts: false` のため `yarn install` で自動取得されない。`yarn playwright install chromium` を手動実行する。CI は `--with-deps` でシステムライブラリも入れる
 - e2e は `tsconfig.app.json` の対象外。型解決のため `tsconfig.e2e.json` を用意し eslint の `parserOptions.project` にも追加してある
+- Playwright の project で機能 E2E (`yarn e2e` = `--project=e2e`) と VRT (`yarn vrt` = `--project=vrt`) を分離。`visual.spec.ts` のみ vrt project。新規の機能 E2E は `e2e` project が自動で拾う (visual.spec.ts 以外)
+- VRT の baseline はフォント差で誤検知しないよう**必ず公式 Docker イメージ `mcr.microsoft.com/playwright:v<version>-noble` + `fonts-noto-cjk`** で生成・比較する。ローカルの素の chromium で生成すると日本語が豆腐になり CI と一致しない。更新は `VRT Update Baselines` ワークフロー (手動) → artifact を `e2e/__screenshots__/` に commit
 
 ### CSS / レイアウト
 - `<input type="file">` の change イベントは同じファイルを再選択しても発火しない。click 前に `inputRef.current.value = ''` でリセットする

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@
 - Playwright のブラウザは `enableScripts: false` のため `yarn install` で自動取得されない。`yarn playwright install chromium` を手動実行する。CI は `--with-deps` でシステムライブラリも入れる
 - e2e は `tsconfig.app.json` の対象外。型解決のため `tsconfig.e2e.json` を用意し eslint の `parserOptions.project` にも追加してある
 - Playwright の project で機能 E2E (`yarn e2e` = `--project=e2e`) と VRT (`yarn vrt` = `--project=vrt`) を分離。`visual.spec.ts` のみ vrt project。新規の機能 E2E は `e2e` project が自動で拾う (visual.spec.ts 以外)
-- VRT の baseline はフォント差で誤検知しないよう**必ず公式 Docker イメージ `mcr.microsoft.com/playwright:v<version>-noble` + `fonts-noto-cjk`** で生成・比較する。ローカルの素の chromium で生成すると日本語が豆腐になり CI と一致しない。更新は `VRT Update Baselines` ワークフロー (手動) → artifact を `e2e/__screenshots__/` に commit
+- VRT の baseline はフォント差で誤検知しないよう**必ず公式 Docker イメージ `mcr.microsoft.com/playwright:v<version>-noble` + `fonts-noto-cjk`** で生成・比較する。ローカルの素の chromium で生成すると日本語が豆腐になり CI と一致しない。更新は `VRT Update Baselines` ワークフロー (手動) → artifact を展開し、最終的に `e2e/__screenshots__/visual.spec.ts/*.png` の配置になるよう commit (二重階層 `e2e/__screenshots__/e2e/...` にしないこと)
 
 ### CSS / レイアウト
 - `<input type="file">` の change イベントは同じファイルを再選択しても発火しない。click 前に `inputRef.current.value = ''` でリセットする

--- a/README.md
+++ b/README.md
@@ -62,12 +62,18 @@ baseline の更新は GitHub Actions の **VRT Update Baselines** ワークフ�
 > [!NOTE]
 > 初回 baseline 投入が済むまで `vrt.yml` は `pull_request` トリガーのみ (main への `push` は付けていない)。baseline を commit したら `push: branches: [main]` を追加して main でも回す。
 
-ローカルで生成・確認する場合は同じイメージを使う:
+baseline 更新は上記の **VRT Update Baselines** ワークフローを使うのが基本 (ローカルを汚さない)。どうしてもローカルで生成する場合は同じイメージを使う:
 
 ```bash
 docker run --rm -v "$(pwd):/work" -w /work mcr.microsoft.com/playwright:v1.60.0-noble \
   sh -c "apt-get update && apt-get install -y fonts-noto-cjk && corepack enable && yarn install --immutable && yarn vrt --update-snapshots"
+
+# コンテナ内は root 実行なので、生成物の所有者をホストユーザーに戻す
+sudo chown -R "$(id -u):$(id -g)" e2e/__screenshots__ node_modules dist
 ```
+
+> [!NOTE]
+> 公式イメージには日本語フォントとして IPAGothic しか入っておらず、CI は `fonts-noto-cjk` を追加して Noto で描画する。**ローカル生成時もフォント追加 (`apt-get install fonts-noto-cjk`) は必須** — 省くと IPAGothic で描画され CI の baseline と一致しない。フォント追加に root が要るためコンテナは root 実行とし、生成物 (`e2e/__screenshots__` のほか `node_modules` / `dist` も root 所有になる) を `chown` で戻すこと。所有権の取り回しが面倒なので、基本は CI ワークフローでの生成を推奨。
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ baseline の更新は GitHub Actions の **VRT Update Baselines** ワークフ�
 2. 生成された `vrt-baselines` artifact をダウンロード
 3. `e2e/__screenshots__/` に展開して commit
 
+> [!NOTE]
+> 初回 baseline 投入が済むまで `vrt.yml` は `pull_request` トリガーのみ (main への `push` は付けていない)。baseline を commit したら `push: branches: [main]` を追加して main でも回す。
+
 ローカルで生成・確認する場合は同じイメージを使う:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ baseline の更新は GitHub Actions の **VRT Update Baselines** ワークフ�
 baseline 更新は上記の **VRT Update Baselines** ワークフローを使うのが基本 (ローカルを汚さない)。どうしてもローカルで生成する場合は同じイメージを使う:
 
 ```bash
-docker run --rm -v "$(pwd):/work" -w /work mcr.microsoft.com/playwright:v1.60.0-noble \
+docker run --rm --user root -v "$(pwd):/work" -w /work mcr.microsoft.com/playwright:v1.60.0-noble \
   sh -c "apt-get update && apt-get install -y fonts-noto-cjk && corepack enable && yarn install --immutable && yarn vrt --update-snapshots"
 
-# コンテナ内は root 実行なので、生成物の所有者をホストユーザーに戻す
+# root で実行したので、生成物の所有者をホストユーザーに戻す
 sudo chown -R "$(id -u):$(id -g)" e2e/__screenshots__ node_modules dist
 ```
 
 > [!NOTE]
-> 公式イメージには日本語フォントとして IPAGothic しか入っておらず、CI は `fonts-noto-cjk` を追加して Noto で描画する。**ローカル生成時もフォント追加 (`apt-get install fonts-noto-cjk`) は必須** — 省くと IPAGothic で描画され CI の baseline と一致しない。フォント追加に root が要るためコンテナは root 実行とし、生成物 (`e2e/__screenshots__` のほか `node_modules` / `dist` も root 所有になる) を `chown` で戻すこと。所有権の取り回しが面倒なので、基本は CI ワークフローでの生成を推奨。
+> 公式イメージには日本語フォントとして IPAGothic しか入っておらず、CI は `fonts-noto-cjk` を追加して Noto で描画する。**ローカル生成時もフォント追加 (`apt-get install fonts-noto-cjk`) は必須** — 省くと IPAGothic で描画され CI の baseline と一致しない。フォント追加 (`apt-get`) に root が要るため `--user root` を明示し、生成物 (`e2e/__screenshots__` のほか `node_modules` / `dist` も root 所有になる) を `chown` で戻すこと。所有権の取り回しが面倒なので、基本は CI ワークフローでの生成を推奨。
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ baseline の更新は GitHub Actions の **VRT Update Baselines** ワークフ�
 
 1. Actions タブから `VRT Update Baselines` を `workflow_dispatch` で実行
 2. 生成された `vrt-baselines` artifact をダウンロード
-3. `e2e/__screenshots__/` に展開して commit
+3. 展開し、最終的に `e2e/__screenshots__/visual.spec.ts/*.png` の配置になるようにして commit する
+
+> [!IMPORTANT]
+> artifact の中身は `e2e/__screenshots__/` 配下のファイル群。展開時に階層を間違えると `e2e/__screenshots__/e2e/__screenshots__/...` の二重階層になりやすい。**最終的に `e2e/__screenshots__/visual.spec.ts/family-tree-light.png` (と dark) が存在する**ことを確認してから commit する。
 
 > [!NOTE]
 > 初回 baseline 投入が済むまで `vrt.yml` は `pull_request` トリガーのみ (main への `push` は付けていない)。baseline を commit したら `push: branches: [main]` を追加して main でも回す。

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ yarn e2e
 > [!NOTE]
 > `.yarnrc.yml` の `enableScripts: false` によりブラウザは `yarn install` 時に自動取得されないため、上記の `yarn playwright install` を手動で実行する。Linux でブラウザ起動に必要なシステムライブラリが足りない場合は `yarn playwright install --with-deps chromium` (要 sudo) を使う。
 
+### VRT (ビジュアルリグレッションテスト)
+
+家系図描画の見た目崩れは Playwright のスクリーンショット比較で検知する (`yarn vrt`)。フォント描画は OS / 環境で差が出るため、**baseline は公式 Playwright Docker イメージで生成・比較する** (CI もこのイメージで実行)。
+
+baseline の更新は GitHub Actions の **VRT Update Baselines** ワークフロー (手動実行) で行う:
+
+1. Actions タブから `VRT Update Baselines` を `workflow_dispatch` で実行
+2. 生成された `vrt-baselines` artifact をダウンロード
+3. `e2e/__screenshots__/` に展開して commit
+
+ローカルで生成・確認する場合は同じイメージを使う:
+
+```bash
+docker run --rm -v "$(pwd):/work" -w /work mcr.microsoft.com/playwright:v1.60.0-noble \
+  sh -c "apt-get update && apt-get install -y fonts-noto-cjk && corepack enable && yarn install --immutable && yarn vrt --update-snapshots"
+```
+
 ## ドキュメント
 
 - [docs/family-tree.md](docs/family-tree.md) — 家系図の表記ルール

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -12,6 +12,10 @@ async function importSampleAndWait(page: Page): Promise<void> {
   await page.locator('input[type="file"]').setInputFiles(SAMPLE_PATH);
   // 家系図ノードが描画されるまで待つ
   await expect(page.getByRole('button', { name: '山田 太郎' })).toBeVisible();
+  // フォント読み込み完了を待つ (未完了で撮ると text のメトリクスが変わり差分が出る)
+  await page.evaluate(async() => {
+    await document.fonts.ready;
+  });
 }
 
 test('家系図 (ライトモード) の見た目', async({ page }) => {

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -1,0 +1,37 @@
+import { expect, type Page, test } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const SAMPLE_PATH = fileURLToPath(new URL('../sample/family-tree.json', import.meta.url));
+
+/*
+ * VRT (visual regression test)。サンプル JSON は固定なので描画は決定論的。
+ * baseline は CI (公式 Playwright Docker イメージ) で生成し、同イメージで比較する。
+ */
+
+async function importSampleAndWait(page: Page): Promise<void> {
+  await page.locator('input[type="file"]').setInputFiles(SAMPLE_PATH);
+  // 家系図ノードが描画されるまで待つ
+  await expect(page.getByRole('button', { name: '山田 太郎' })).toBeVisible();
+}
+
+test('家系図 (ライトモード) の見た目', async({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('theme', 'light');
+  });
+  await page.goto('/');
+  await importSampleAndWait(page);
+  await expect(page).toHaveScreenshot('family-tree-light.png', {
+    fullPage: true,
+  });
+});
+
+test('家系図 (ダークモード) の見た目', async({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('theme', 'dark');
+  });
+  await page.goto('/');
+  await importSampleAndWait(page);
+  await expect(page).toHaveScreenshot('family-tree-dark.png', {
+    fullPage: true,
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "e2e": "playwright test",
+    "e2e": "playwright test --project=e2e",
+    "vrt": "playwright test --project=vrt",
     "hooks:install": "git config core.hooksPath .githooks"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,12 +35,12 @@ export default defineConfig({
   projects: [
     {
       name: 'e2e',
-      testIgnore: /visual\.spec\.ts/u,
+      testIgnore: /visual\.spec\.ts$/u,
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'vrt',
-      testMatch: /visual\.spec\.ts/u,
+      testMatch: /visual\.spec\.ts$/u,
       use: { ...devices['Desktop Chrome'] },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,8 +4,9 @@ const PORT = 4173;
 const BASE_URL = `http://localhost:${PORT.toString()}`;
 
 /*
- * E2E 設定。VRT (スクリーンショット比較) は baseline 戦略の検討が必要なため #154 で別途対応。
- * webServer は本番ビルドを preview で配信する (dev サーバより挙動が本番に近い)。
+ * E2E + VRT 設定。webServer は本番ビルドを preview で配信する (dev サーバより本番に近い)。
+ * VRT の baseline はフォント差を避けるため公式 Playwright Docker イメージで生成・比較する
+ * (CI / ローカルとも同イメージを使う前提)。
  */
 export default defineConfig({
   testDir: './e2e',
@@ -15,13 +16,31 @@ export default defineConfig({
   reporter: process.env.CI === undefined
     ? 'list'
     : [['list'], ['html', { open: 'never' }]],
+  // baseline は OS ごとに分けず、固定名で管理する (生成・比較を同一 Docker イメージに統一するため)
+  snapshotPathTemplate: '{testDir}/__screenshots__/{testFilePath}/{arg}{ext}',
+  expect: {
+    // アンチエイリアス由来の微差を許容する
+    toHaveScreenshot: { maxDiffPixelRatio: 0.01 },
+  },
   use: {
     baseURL: BASE_URL,
     trace: 'on-first-retry',
   },
+
+  /*
+   * 機能 E2E (e2e) と VRT (vrt) を project で分ける。
+   * VRT はフォント差を避けるため公式 Docker イメージでのみ実行する想定なので、
+   * `yarn e2e` (= --project=e2e) と `yarn vrt` (= --project=vrt) で呼び分ける。
+   */
   projects: [
     {
-      name: 'chromium',
+      name: 'e2e',
+      testIgnore: /visual\.spec\.ts/u,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'vrt',
+      testMatch: /visual\.spec\.ts/u,
       use: { ...devices['Desktop Chrome'] },
     },
   ],

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- `e2e/visual.spec.ts` で家系図 (ライト/ダーク) のスクリーンショット比較を追加
- Playwright の project で機能 E2E (`yarn e2e`) と VRT (`yarn vrt`) を分離
- VRT 専用 CI: `vrt.yml` (PR ごとに比較) / `vrt-update.yml` (手動で baseline 生成 → artifact)
- フォント差で誤検知しないよう、比較・生成とも**公式 Playwright Docker イメージ + `fonts-noto-cjk`** に統一

## baseline のブートストラップ手順 (マージ後に必要)
`workflow_dispatch` のワークフローは **default ブランチ (main) に存在しないと起動できない** GitHub の仕様のため、baseline はこの PR には含めず、マージ後に以下で投入する:

1. このPRをマージ (この時点では `vrt` チェックは baseline 不在で **赤** になる — 想定内)
2. Actions タブ → `VRT Update Baselines` を実行 (main に対して)
3. 生成された `vrt-baselines` artifact をダウンロード → `e2e/__screenshots__/` に展開
4. 別 PR で baseline を commit → 以降 `vrt` チェックが緑になる

> [!NOTE]
> そのため本 PR の `vrt` チェックは赤のままになります。`e2e` (機能) / `verify` / `lint` が緑であることを確認してマージしてください。

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit` / `tsconfig.e2e.json`
- [x] `yarn test` (95/95)
- [x] `yarn e2e` (5/5 — VRT 除外を確認)
- [x] VRT のロジックはローカルで動作確認済 (baseline 生成→比較。フォントは CI 側で担保)
- [ ] マージ後に baseline を投入し `vrt` が緑になること

Closes #154