### PR TITLE
[#154] VRT 撮影前にトースト消失を待つ

### DIFF
--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -12,6 +12,12 @@ async function importSampleAndWait(page: Page): Promise<void> {
   await page.locator('input[type="file"]').setInputFiles(SAMPLE_PATH);
   // 家系図ノードが描画されるまで待つ
   await expect(page.getByRole('button', { name: '山田 太郎' })).toBeVisible();
+
+  /*
+   * インポート成功トーストは数秒で消える時間依存要素なので、消えてから撮る
+   * (写り込むと VRT が flaky になる)。
+   */
+  await expect(page.getByText('インポートに成功しました。')).toBeHidden({ timeout: 15_000 });
   // フォント読み込み完了を待つ (未完了で撮ると text のメトリクスが変わり差分が出る)
   await page.evaluate(async() => {
     await document.fonts.ready;


### PR DESCRIPTION
## Summary
- CI 生成の baseline を目視確認したところ、数秒で消える「インポートに成功しました」トーストが写り込んでいた
- 時間依存要素を baseline に含めると VRT が flaky になるため、撮影前にトーストが hidden になるのを待つよう修正

## 背景
`VRT Update Baselines` で生成した baseline (light/dark) を確認したら、右上に成功トーストが残っていた。このまま baseline 化すると、次回比較時にトーストの有無/フェード状態が変わり毎回差分が出る。

## このあとの手順 (baseline 投入)
1. この PR をマージ
2. `VRT Update Baselines` を再実行 → トースト無しの `vrt-baselines` を取得
3. 別 PR で baseline を commit + `vrt.yml` に `push: branches: [main]` を追加

## Test plan
- [x] `yarn lint`
- [ ] マージ後の baseline にトーストが写り込まないこと

Closes #154