### PR TITLE
[#157] PR レビュー用に現在のスクショを常時 artifact 化

### DIFF
--- a/.github/workflows/vrt-run.yml
+++ b/.github/workflows/vrt-run.yml
@@ -15,6 +15,10 @@ on:
         description: Playwright 公式 Docker イメージ (@playwright/test と版を揃える)
         type: string
         default: mcr.microsoft.com/playwright:v1.60.0-noble
+      snapshot-artifact-name:
+        description: update-snapshots=true のときに生成スクショを上げる artifact 名
+        type: string
+        default: vrt-baselines
 
 permissions:
   contents: read
@@ -74,11 +78,11 @@ jobs:
           # 依存インストール失敗等で report 未生成のとき、二次的な path not found を避ける
           if-no-files-found: ignore
 
-      - name: Upload baselines
+      - name: Upload snapshots
         if: ${{ inputs['update-snapshots'] }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: vrt-baselines
+          name: ${{ inputs['snapshot-artifact-name'] }}
           path: e2e/__screenshots__/
           retention-days: 7
           # 生成途中で失敗し screenshots 未作成のとき、二次的な path not found を避ける

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -20,9 +20,11 @@ jobs:
     with:
       update-snapshots: false
 
-  # レビュー用に「現在のブランチの見た目」を常に artifact 化する。
+  # PR レビュー用に「現在のブランチの見た目」を artifact 化する。
   # compare の pass/fail に依存せず撮るので、新規画面や差分なしでもスクショを確認できる。
+  # main への push では不要 (レビュー対象でない) ので PR のときだけ走らせる。
   preview:
+    if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/vrt-run.yml
     with:
       update-snapshots: true

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -14,7 +14,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # baseline との比較 (リグレッション検知の本体)
   compare:
     uses: ./.github/workflows/vrt-run.yml
     with:
       update-snapshots: false
+
+  # レビュー用に「現在のブランチの見た目」を常に artifact 化する。
+  # compare の pass/fail に依存せず撮るので、新規画面や差分なしでもスクショを確認できる。
+  preview:
+    uses: ./.github/workflows/vrt-run.yml
+    with:
+      update-snapshots: true
+      snapshot-artifact-name: vrt-current

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@
 - e2e は `tsconfig.app.json` の対象外。型解決のため `tsconfig.e2e.json` を用意し eslint の `parserOptions.project` にも追加してある
 - Playwright の project で機能 E2E (`yarn e2e` = `--project=e2e`) と VRT (`yarn vrt` = `--project=vrt`) を分離。`visual.spec.ts` のみ vrt project。新規の機能 E2E は `e2e` project が自動で拾う (visual.spec.ts 以外)
 - VRT の baseline はフォント差で誤検知しないよう**必ず公式 Docker イメージ `mcr.microsoft.com/playwright:v<version>-noble` + `fonts-noto-cjk`** で生成・比較する。ローカルの素の chromium で生成すると日本語が豆腐になり CI と一致しない。更新は `VRT Update Baselines` ワークフロー (手動) → artifact を展開し、最終的に `e2e/__screenshots__/visual.spec.ts/*.png` の配置になるよう commit (二重階層 `e2e/__screenshots__/e2e/...` にしないこと)
+- VRT ジョブは比較とは別に「現在の見た目」を `vrt-current` artifact として毎 PR 出力する。`gh run download <run-id> -n vrt-current` で取得して見た目レビューに使う (リグレッション差分の有無に依存せず取れる)。baseline 更新の `vrt-baselines` とは artifact 名で区別 (`vrt-run.yml` の `snapshot-artifact-name` input)
 
 ### CSS / レイアウト
 - `<input type="file">` の change イベントは同じファイルを再選択しても発火しない。click 前に `inputRef.current.value = ''` でリセットする

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ baseline の更新は GitHub Actions の **VRT Update Baselines** ワークフ�
 > [!IMPORTANT]
 > artifact の中身は `e2e/__screenshots__/` 配下のファイル群。展開時に階層を間違えると `e2e/__screenshots__/e2e/__screenshots__/...` の二重階層になりやすい。**最終的に `e2e/__screenshots__/visual.spec.ts/family-tree-light.png` (と dark) が存在する**ことを確認してから commit する。
 
+#### PR レビュー用の現在スクショ
+
+VRT ジョブは比較とは別に、**そのブランチの現在の見た目**を `vrt-current` artifact として毎 PR で出力する (リグレッション差分の有無に関わらず取得できる)。新規画面や「見やすさ」の確認に使う:
+
+```bash
+# 対象 PR の最新 VRT 実行から現在スクショを取得
+gh run download <run-id> -n vrt-current -D /tmp/vrt-current
+```
+
 
 baseline 更新は上記の **VRT Update Baselines** ワークフローを使うのが基本 (ローカルを汚さない)。どうしてもローカルで生成する場合は同じイメージを使う:
 


### PR DESCRIPTION
## Summary
- VRT ジョブに `preview` を追加し、比較 (compare) とは独立に**そのブランチの現在の見た目**を `vrt-current` artifact として毎 PR 出力する
- これにより差分の有無に関わらずスクショを取得でき、新規画面や「見やすさ」のレビューに使える
- `vrt-run.yml` に `snapshot-artifact-name` input を追加し、baseline 更新 (`vrt-baselines`) と PR プレビュー (`vrt-current`) を artifact 名で区別

## 使い方 (Claude が PR レビュー時に実行)
```bash
gh run download <run-id> -n vrt-current -D /tmp/vrt-current
```
取得した PNG を読んでレイアウト・コントラスト・はみ出し等を目視レビューする。

## 補足
- VRT が PR ごとにコンテナを 2 回 (compare + preview) 起動するため CI 時間は増えるが、public リポジトリのため金銭コストは増えない
- 色のコントラスト等を**客観基準**で自動検知したい場合は別途 `@axe-core/playwright` の a11y チェック導入を検討 (#157 本文の補足参照)

## Test plan
- [x] `yarn lint`
- [ ] PR で `vrt-current` artifact が生成されること
- [ ] `gh run download` で取得 → 現在の家系図スクショが確認できること

Closes #157