### PR TITLE
[#146] 嫁入り/婿入り (householdSide) のデータ層とレイアウト反映

### DIFF
--- a/src/components/familyTree/layout/buildUnits.test.ts
+++ b/src/components/familyTree/layout/buildUnits.test.ts
@@ -6,7 +6,7 @@ import {
   buildSingleUnits,
 } from '@/components/familyTree/layout/buildUnits';
 import { type Person, Sex } from '@/schemas/personSchema';
-import { type Relation, RelationType } from '@/schemas/relationSchema';
+import { HouseholdSide, type Relation, RelationType } from '@/schemas/relationSchema';
 
 const ID = {
   PARENT: '11111111-1111-4111-8111-111111111111',
@@ -77,6 +77,38 @@ describe('buildCoupleUnits', () => {
     );
     const { units } = buildCoupleUnits([rel], new Map());
     expect(units[0].marriageType).toBe('couple');
+  });
+
+  it('householdSide 未指定なら householdHeadPersonId は null (personIds 順も不変)', () => {
+    const rel = makeRelation(
+      ID.REL_MARRIED,
+      RelationType.MARRIED_COUPLE,
+      ID.HUSBAND,
+      ID.WIFE,
+    );
+    const { units } = buildCoupleUnits([rel], new Map());
+    expect(units[0].householdHeadPersonId).toBeNull();
+    expect(units[0].personIds).toEqual([ID.HUSBAND, ID.WIFE]);
+  });
+
+  it('householdSide=person2 なら householdHeadPersonId=p2 (personIds 順は変えない)', () => {
+    const rel: Relation = {
+      ...makeRelation(ID.REL_MARRIED, RelationType.MARRIED_COUPLE, ID.HUSBAND, ID.WIFE),
+      householdSide: HouseholdSide.PERSON2,
+    };
+    const { units } = buildCoupleUnits([rel], new Map());
+    expect(units[0].householdHeadPersonId).toBe(ID.WIFE);
+    // 視覚順 (personIds) は person1, person2 のまま
+    expect(units[0].personIds).toEqual([ID.HUSBAND, ID.WIFE]);
+  });
+
+  it('householdSide=person1 なら householdHeadPersonId=p1', () => {
+    const rel: Relation = {
+      ...makeRelation(ID.REL_MARRIED, RelationType.MARRIED_COUPLE, ID.HUSBAND, ID.WIFE),
+      householdSide: HouseholdSide.PERSON1,
+    };
+    const { units } = buildCoupleUnits([rel], new Map());
+    expect(units[0].householdHeadPersonId).toBe(ID.HUSBAND);
   });
 
   it('親子関係は無視する', () => {

--- a/src/components/familyTree/layout/buildUnits.ts
+++ b/src/components/familyTree/layout/buildUnits.ts
@@ -4,7 +4,7 @@ import {
   type Unit,
 } from '@/components/familyTree/layout/internalTypes';
 import { type Person } from '@/schemas/personSchema';
-import { type Relation, RelationType } from '@/schemas/relationSchema';
+import { HouseholdSide, type Relation, RelationType } from '@/schemas/relationSchema';
 
 export interface SecondaryMarriage {
   relationId: string;
@@ -17,6 +17,17 @@ export interface SecondaryMarriage {
 export interface CoupleBuildResult {
   units: Unit[];
   secondaryMarriages: SecondaryMarriage[];
+}
+
+// householdSide に対応する人物 id を返す。未指定なら null (= 従来どおり personId1 が primary)。
+function resolveHouseholdHead(rel: Relation, p1: string, p2: string): string | null {
+  if (rel.householdSide === HouseholdSide.PERSON1) {
+    return p1;
+  }
+  if (rel.householdSide === HouseholdSide.PERSON2) {
+    return p2;
+  }
+  return null;
 }
 
 function classifyMarriage(rel: Relation): MarriageLineType | null {
@@ -83,6 +94,7 @@ export function buildCoupleUnits(
       marriageRelationId: rel.id,
       marriageType,
       marriageDivorced: rel.divorced ?? false,
+      householdHeadPersonId: resolveHouseholdHead(rel, p1, p2),
       generation: 0,
     });
     unitOfPerson.set(p1, id);
@@ -111,6 +123,7 @@ export function buildSingleUnits(
       marriageRelationId: null,
       marriageType: null,
       marriageDivorced: false,
+      householdHeadPersonId: null,
       generation: 0,
     });
     unitOfPerson.set(p.id, id);

--- a/src/components/familyTree/layout/generations.test.ts
+++ b/src/components/familyTree/layout/generations.test.ts
@@ -22,6 +22,7 @@ function singleUnit(id: string, personId: string): Unit {
     marriageRelationId: null,
     marriageType: null,
     marriageDivorced: false,
+    householdHeadPersonId: null,
     generation: 0,
   };
 }

--- a/src/components/familyTree/layout/internalTypes.ts
+++ b/src/components/familyTree/layout/internalTypes.ts
@@ -26,6 +26,8 @@ export interface Unit {
   marriageRelationId: string | null;
   marriageType: MarriageLineType | null;
   marriageDivorced: boolean;
+  // 家系を継ぐ側の人物 (この人の親系統を primary にする)。未指定は null。
+  householdHeadPersonId: string | null;
   generation: number;
 }
 

--- a/src/components/familyTree/layout/ownership.test.ts
+++ b/src/components/familyTree/layout/ownership.test.ts
@@ -25,6 +25,7 @@ function singleUnit(id: string, personId: string): Unit {
     marriageRelationId: null,
     marriageType: null,
     marriageDivorced: false,
+    householdHeadPersonId: null,
     generation: 0,
   };
 }
@@ -37,6 +38,7 @@ function coupleUnit(id: string, p1: string, p2: string): Unit {
     marriageRelationId: 'rel',
     marriageType: 'married',
     marriageDivorced: false,
+    householdHeadPersonId: null,
     generation: 0,
   };
 }
@@ -105,6 +107,57 @@ describe('computeOwnership', () => {
     const result = computeOwnership(units, unitOfPerson, childToParents);
     expect(result.childrenOfUnit.get('u-couple')).toEqual(['u-child']);
     expect(result.secondaryParentsOfUnit.size).toBe(0);
+  });
+
+  it('householdHeadPersonId が指定された側の親系統が primary になる', () => {
+    // 子夫婦 = [CHILD(親=u-pa), WIFE(親=u-pb)]。householdHead を WIFE 側にすると u-pb が primary。
+    const childCouple = {
+      ...coupleUnit('u-childcouple', ID.CHILD, ID.WIFE),
+      householdHeadPersonId: ID.WIFE,
+    };
+    const units = [
+      singleUnit('u-pa', ID.HUSBAND),
+      singleUnit('u-pb', ID.PARENT),
+      childCouple,
+    ];
+    const unitOfPerson = new Map([
+      [ID.HUSBAND, 'u-pa'],
+      [ID.PARENT, 'u-pb'],
+      [ID.CHILD, 'u-childcouple'],
+      [ID.WIFE, 'u-childcouple'],
+    ]);
+    const childToParents = new Map([
+      [ID.CHILD, [link(ID.HUSBAND)]],
+      [ID.WIFE, [link(ID.PARENT)]],
+    ]);
+    const result = computeOwnership(units, unitOfPerson, childToParents);
+    // WIFE 側の親ユニット u-pb が primary
+    expect(result.childrenOfUnit.get('u-pb')).toEqual(['u-childcouple']);
+    // CHILD 側の u-pa は secondary
+    expect(result.secondaryParentsOfUnit.get('u-childcouple')).toEqual(['u-pa']);
+  });
+
+  it('householdHeadPersonId 未指定なら personIds 先頭 (=person1) 側が primary', () => {
+    const childCouple = coupleUnit('u-childcouple', ID.CHILD, ID.WIFE);
+    const units = [
+      singleUnit('u-pa', ID.HUSBAND),
+      singleUnit('u-pb', ID.PARENT),
+      childCouple,
+    ];
+    const unitOfPerson = new Map([
+      [ID.HUSBAND, 'u-pa'],
+      [ID.PARENT, 'u-pb'],
+      [ID.CHILD, 'u-childcouple'],
+      [ID.WIFE, 'u-childcouple'],
+    ]);
+    const childToParents = new Map([
+      [ID.CHILD, [link(ID.HUSBAND)]],
+      [ID.WIFE, [link(ID.PARENT)]],
+    ]);
+    const result = computeOwnership(units, unitOfPerson, childToParents);
+    // 先頭 CHILD 側の u-pa が primary
+    expect(result.childrenOfUnit.get('u-pa')).toEqual(['u-childcouple']);
+    expect(result.secondaryParentsOfUnit.get('u-childcouple')).toEqual(['u-pb']);
   });
 });
 

--- a/src/components/familyTree/layout/ownership.ts
+++ b/src/components/familyTree/layout/ownership.ts
@@ -6,6 +6,19 @@ export interface OwnershipResult {
   rootUnitIds: string[];
 }
 
+/*
+ * householdHeadPersonId が指定されていれば、その人物を先頭にした personIds 順を返す。
+ * 親ユニット探索はこの順で行われ、先に見つかった親ユニットが primary になるため、
+ * 「家系を継ぐ側」の親系統が primary に選ばれる。視覚上の personIds 順は変えない。
+ */
+function orderedPersonIds(unit: Unit): string[] {
+  const head = unit.householdHeadPersonId;
+  if (head === null || !unit.personIds.includes(head)) {
+    return unit.personIds;
+  }
+  return [head, ...unit.personIds.filter((pid) => pid !== head)];
+}
+
 function findAllParentUnits(
   unit: Unit,
   unitOfPerson: Map<string, string>,
@@ -13,7 +26,7 @@ function findAllParentUnits(
 ): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
-  for (const pid of unit.personIds) {
+  for (const pid of orderedPersonIds(unit)) {
     const parents = childToParents.get(pid) ?? [];
     for (const { parentId } of parents) {
       const ownerId = unitOfPerson.get(parentId);

--- a/src/components/familyTree/layout/secondaryParents.test.ts
+++ b/src/components/familyTree/layout/secondaryParents.test.ts
@@ -27,6 +27,7 @@ function singleUnit(id: string, personId: string): Unit {
     marriageRelationId: null,
     marriageType: null,
     marriageDivorced: false,
+    householdHeadPersonId: null,
     generation: 0,
   };
 }
@@ -39,6 +40,7 @@ function coupleUnit(id: string, p1: string, p2: string): Unit {
     marriageRelationId: 'rel',
     marriageType: 'married',
     marriageDivorced: false,
+    householdHeadPersonId: null,
     generation: 0,
   };
 }

--- a/src/components/familyTree/layout/sortChildren.test.ts
+++ b/src/components/familyTree/layout/sortChildren.test.ts
@@ -35,6 +35,7 @@ function singleUnit(id: string, personId: string): Unit {
     marriageRelationId: null,
     marriageType: null,
     marriageDivorced: false,
+    householdHeadPersonId: null,
     generation: 0,
   };
 }

--- a/src/components/familyTree/layout/subtreeWidth.test.ts
+++ b/src/components/familyTree/layout/subtreeWidth.test.ts
@@ -19,6 +19,7 @@ function singleUnit(id: string): Unit {
     marriageRelationId: null,
     marriageType: null,
     marriageDivorced: false,
+    householdHeadPersonId: null,
     generation: 0,
   };
 }
@@ -31,6 +32,7 @@ function coupleUnit(id: string): Unit {
     marriageRelationId: 'rel',
     marriageType: 'married',
     marriageDivorced: false,
+    householdHeadPersonId: null,
     generation: 0,
   };
 }

--- a/src/schemas/relationSchema.test.ts
+++ b/src/schemas/relationSchema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { relationSchema, RelationType } from '@/schemas/relationSchema';
+import { HouseholdSide, relationSchema, RelationType } from '@/schemas/relationSchema';
 
 const P1 = '11111111-1111-4111-8111-111111111111';
 const P2 = '22222222-2222-4222-8222-222222222222';
@@ -55,6 +55,45 @@ describe('relationSchema divorced refinement', () => {
   });
 
   it('divorced を未指定なら全リレーションタイプで通る', () => {
+    for (const t of Object.values(RelationType)) {
+      const result = relationSchema.safeParse({
+        id: REL_ID,
+        relationType: [t],
+        persons: { personId1: [P1],
+          personId2: [P2] },
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+});
+
+describe('relationSchema householdSide refinement', () => {
+  it('夫婦に householdSide を指定するのは OK', () => {
+    const result = relationSchema.safeParse({
+      id: REL_ID,
+      relationType: [RelationType.MARRIED_COUPLE],
+      persons: { personId1: [P1],
+        personId2: [P2] },
+      householdSide: HouseholdSide.PERSON2,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('親子関係に householdSide を指定するとエラー', () => {
+    const result = relationSchema.safeParse({
+      id: REL_ID,
+      relationType: [RelationType.PARENT_CHILD],
+      persons: { personId1: [P1],
+        personId2: [P2] },
+      householdSide: HouseholdSide.PERSON1,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['householdSide']);
+    }
+  });
+
+  it('未指定なら全リレーションタイプで通る', () => {
     for (const t of Object.values(RelationType)) {
       const result = relationSchema.safeParse({
         id: REL_ID,

--- a/src/schemas/relationSchema.ts
+++ b/src/schemas/relationSchema.ts
@@ -9,6 +9,13 @@ export const RelationType = {
 
 export type RelationType = typeof RelationType[keyof typeof RelationType];
 
+export const HouseholdSide = {
+  PERSON1: 'person1',
+  PERSON2: 'person2',
+} as const;
+
+export type HouseholdSide = typeof HouseholdSide[keyof typeof HouseholdSide];
+
 export const relationTypeList = [
   {
     label: '親子(実子)',
@@ -63,15 +70,28 @@ export const relationSchema = z.object({
   // 婚姻 (married-couple / couple) の解消フラグ。親子関係では指定不可。
   divorced: z.boolean().optional()
     .describe('離婚済み'),
+
+  /*
+   * 家系を継ぐ側 (= レイアウトで自分の親系統を primary にする側)。婚姻関係でのみ指定可。
+   * 未指定なら従来どおり personId1 側が primary になる。
+   */
+  householdSide: z.enum(Object.values(HouseholdSide) as [string, ...string[]]).optional()
+    .describe('家系を継ぐ側'),
 }).superRefine((val, ctx) => {
-  if (val.divorced === undefined) {
-    return;
-  }
-  if (val.relationType.length === 0 || !MARRIAGE_RELATION_TYPES.includes(val.relationType[0])) {
+  const isMarriage = val.relationType.length > 0
+    && MARRIAGE_RELATION_TYPES.includes(val.relationType[0]);
+  if (val.divorced !== undefined && !isMarriage) {
     ctx.addIssue({
       code: 'custom',
       message: '離婚フラグは婚姻関係 (夫婦 / 事実婚) でのみ指定できます。',
       path: ['divorced'],
+    });
+  }
+  if (val.householdSide !== undefined && !isMarriage) {
+    ctx.addIssue({
+      code: 'custom',
+      message: '家系を継ぐ側は婚姻関係 (夫婦 / 事実婚) でのみ指定できます。',
+      path: ['householdSide'],
     });
   }
 });

--- a/src/schemas/relationSchema.ts
+++ b/src/schemas/relationSchema.ts
@@ -74,8 +74,9 @@ export const relationSchema = z.object({
   /*
    * 家系を継ぐ側 (= レイアウトで自分の親系統を primary にする側)。婚姻関係でのみ指定可。
    * 未指定なら従来どおり personId1 側が primary になる。
+   * 値のタプルを直接渡し、出力型を 'person1' | 'person2' の union に保つ。
    */
-  householdSide: z.enum(Object.values(HouseholdSide) as [string, ...string[]]).optional()
+  householdSide: z.enum([HouseholdSide.PERSON1, HouseholdSide.PERSON2]).optional()
     .describe('家系を継ぐ側'),
 }).superRefine((val, ctx) => {
   const isMarriage = val.relationType.length > 0


### PR DESCRIPTION
## Summary
- `relationSchema` に optional `householdSide: 'person1' | 'person2'` を追加 (家系を継ぐ側)。婚姻関係でのみ指定可 (superRefine)
- `Unit` に `householdHeadPersonId` を持たせ、`computeOwnership` の親ユニット探索順を「家を継ぐ側」優先に変更。これによりその人物の親系統が primary になる
- **personIds の視覚順 (couple の左右配置) は変えない** — 親優先のみ切り替える
- 未指定時は従来どおり person1 側が primary (後方互換)

## スコープ (サブ issue に分割)
本 PR はデータ層 + ロジックのみ。以下は別 issue:
- **#163**: AddRelationDialog の「家系を継ぐ側」入力 UI
- **#164**: 婚姻線付近の嫁入り/婿入りラベル表示
- **#151**: 本家のみフィルタ (householdSide を利用)

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings — 既存)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] `yarn test` (100/100 — schema refine 3 + ownership householdHead 2 ケース追加)
- [x] `yarn build`

Closes #146