### PR TITLE
[#163] AddRelationDialog に「家系を継ぐ側」入力 UI を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@
 - Playwright の project で機能 E2E (`yarn e2e` = `--project=e2e`) と VRT (`yarn vrt` = `--project=vrt`) を分離。`visual.spec.ts` のみ vrt project。新規の機能 E2E は `e2e` project が自動で拾う (visual.spec.ts 以外)
 - VRT の baseline はフォント差で誤検知しないよう**必ず公式 Docker イメージ `mcr.microsoft.com/playwright:v<version>-noble` + `fonts-noto-cjk`** で生成・比較する。ローカルの素の chromium で生成すると日本語が豆腐になり CI と一致しない。更新は `VRT Update Baselines` ワークフロー (手動) → artifact を展開し、最終的に `e2e/__screenshots__/visual.spec.ts/*.png` の配置になるよう commit (二重階層 `e2e/__screenshots__/e2e/...` にしないこと)
 - VRT ジョブは比較とは別に「現在の見た目」を `vrt-current` artifact として毎 PR 出力する。`gh run download <run-id> -n vrt-current` で取得して見た目レビューに使う (リグレッション差分の有無に依存せず取れる)。baseline 更新の `vrt-baselines` とは artifact 名で区別 (`vrt-run.yml` の `snapshot-artifact-name` input)
+- **Chakra v3 の `Select` (特に Dialog 内・ポータルの listbox) は headless Playwright で安定して駆動できない**。listbox が開き option も a11y ツリーに出るが、click/force click/keyboard/native `<select>` の selectOption いずれも不安定 (描画自体は正しく、実ブラウザでは動く)。`reducedMotion: 'reduce'` でも改善せず (アニメーションが原因ではない。Dialog の focus-trap と body 直下ポータルの相互作用が疑わしい)。E2E では Select の選択を伴うフローは避け、ロジックは単体テスト + 必要なら Docker スクショの目視で担保する。`Input` / `RadioGroup` 系 (PersonDialog) は問題なく駆動できる
 
 ### CSS / レイアウト
 - `<input type="file">` の change イベントは同じファイルを再選択しても発火しない。click 前に `inputRef.current.value = ''` でリセットする

--- a/e2e/family-tree.spec.ts
+++ b/e2e/family-tree.spec.ts
@@ -41,3 +41,17 @@ test('インポート後にノードをクリックすると編集ダイアロ�
   await expect(page.getByText('人物編集')).toBeVisible();
   await expect(page.getByPlaceholder('姓', { exact: true })).toHaveValue('山田');
 });
+
+test('関係追加ダイアログの初期状態では「家系を継ぐ側」は出ない', async({ page }) => {
+  await page.getByRole('button', { name: '関係追加' }).click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByText('関係追加')).toBeVisible();
+
+  /*
+   * 婚姻関係を選ぶ前は householdSide / divorced は非表示。
+   * 婚姻選択後の表示は Chakra Select の駆動が headless で不安定なため E2E では検証しない。
+   * 値 → primary 親の反映は ownership / buildUnits の単体テストでカバー。
+   */
+  await expect(dialog.getByText('家系を継ぐ側 (任意)')).toBeHidden();
+  await expect(dialog.getByText('離婚済み')).toBeHidden();
+});

--- a/src/components/relation/AddRelationDialog.tsx
+++ b/src/components/relation/AddRelationDialog.tsx
@@ -1,13 +1,14 @@
-import { Button, Checkbox, CloseButton, createListCollection, Dialog, Field, Flex, Portal, Select } from '@chakra-ui/react';
+import { Button, Checkbox, CloseButton, createListCollection, Dialog, Field, Flex, Portal, RadioGroup, Select } from '@chakra-ui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { v4 as uuidv4 } from 'uuid';
 
+import { RelationPersonField } from '@/components/relation/RelationPersonField';
 import { PrimaryButton } from '@/components/ui/PrimaryButton';
 import { toaster } from '@/components/ui/toaster';
 import { type Person } from '@/schemas/personSchema';
-import { type Relation, relationSchema, RelationType, relationTypeList } from '@/schemas/relationSchema';
+import { HouseholdSide, type Relation, relationSchema, RelationType, relationTypeList } from '@/schemas/relationSchema';
 import { usePeopleStore } from '@/store/personStore';
 import { useRelationStore } from '@/store/relationStore';
 
@@ -132,107 +133,23 @@ export function AddRelationDialog({ isOpen, onOpenChange }: AddRelationDialogPro
                   {selectedRelationType
                     ? (
                       <>
-                        <Field.Root invalid={Boolean(errors.persons) || Boolean(errors.persons?.personId1)}>
+                        <RelationPersonField
+                          control={control}
+                          errorMessages={[errors.persons?.message, errors.persons?.personId1?.message]}
+                          invalid={Boolean(errors.persons) || Boolean(errors.persons?.personId1)}
+                          label={selectedRelationType.person1Label}
+                          name="persons.personId1"
+                          personCollection={personCollection}
+                        />
 
-                          <Field.Label>{selectedRelationType.person1Label}</Field.Label>
-
-                          <Controller
-                            control={control}
-                            name="persons.personId1"
-                            render={({ field }) => (
-                              <Select.Root
-                                collection={personCollection}
-                                defaultValue={field.value}
-                                name={field.name}
-                                onInteractOutside={field.onBlur}
-                                onValueChange={({ value }) => { field.onChange(value); }}
-                                value={field.value}
-                              >
-                                <Select.HiddenSelect />
-
-                                <Select.Control>
-                                  <Select.Trigger>
-                                    <Select.ValueText placeholder={selectedRelationType.person1Label} />
-                                  </Select.Trigger>
-
-                                  <Select.IndicatorGroup>
-                                    <Select.Indicator />
-                                  </Select.IndicatorGroup>
-                                </Select.Control>
-
-                                <Portal>
-                                  <Select.Positioner>
-                                    <Select.Content zIndex={1500}>
-                                      {personCollection.items.map((person) => (
-                                        <Select.Item
-                                          item={person}
-                                          key={person.value}
-                                        >
-                                          {person.label}
-                                          <Select.ItemIndicator />
-                                        </Select.Item>
-                                      ))}
-                                    </Select.Content>
-                                  </Select.Positioner>
-                                </Portal>
-                              </Select.Root>
-                            )}
-                          />
-
-                          <Field.ErrorText>{errors.persons?.message}</Field.ErrorText>
-                          <Field.ErrorText>{errors.persons?.personId1?.message}</Field.ErrorText>
-                        </Field.Root>
-
-                        <Field.Root invalid={Boolean(errors.persons) || Boolean(errors.persons?.personId2)}>
-
-                          <Field.Label>{selectedRelationType.person2Label}</Field.Label>
-
-                          <Controller
-                            control={control}
-                            name="persons.personId2"
-                            render={({ field }) => (
-                              <Select.Root
-                                collection={personCollection}
-                                defaultValue={field.value}
-                                name={field.name}
-                                onInteractOutside={field.onBlur}
-                                onValueChange={({ value }) => { field.onChange(value); }}
-                                value={field.value}
-                              >
-                                <Select.HiddenSelect />
-
-                                <Select.Control>
-                                  <Select.Trigger>
-                                    <Select.ValueText placeholder={selectedRelationType.person2Label} />
-                                  </Select.Trigger>
-
-                                  <Select.IndicatorGroup>
-                                    <Select.Indicator />
-                                  </Select.IndicatorGroup>
-                                </Select.Control>
-
-                                <Portal>
-                                  <Select.Positioner>
-                                    <Select.Content zIndex={1500}>
-                                      {personCollection.items.map((person) => (
-                                        <Select.Item
-                                          item={person}
-                                          key={person.value}
-                                        >
-                                          {person.label}
-                                          <Select.ItemIndicator />
-                                        </Select.Item>
-                                      ))}
-                                    </Select.Content>
-                                  </Select.Positioner>
-                                </Portal>
-                              </Select.Root>
-                            )}
-                          />
-
-                          <Field.ErrorText>{errors.persons?.message}</Field.ErrorText>
-                          <Field.ErrorText>{errors.persons?.personId2?.message}</Field.ErrorText>
-                        </Field.Root>
+                        <RelationPersonField
+                          control={control}
+                          errorMessages={[errors.persons?.message, errors.persons?.personId2?.message]}
+                          invalid={Boolean(errors.persons) || Boolean(errors.persons?.personId2)}
+                          label={selectedRelationType.person2Label}
+                          name="persons.personId2"
+                          personCollection={personCollection}
+                        />
 
                         {isMarriageRelation
                           ? (
@@ -268,6 +185,61 @@ export function AddRelationDialog({ isOpen, onOpenChange }: AddRelationDialogPro
                               />
 
                               <Field.ErrorText>{errors.divorced?.message}</Field.ErrorText>
+                            </Field.Root>
+                          )
+                          : null}
+
+                        {isMarriageRelation
+                          ? (
+                            <Field.Root invalid={Boolean(errors.householdSide)}>
+                              <Field.Label>家系を継ぐ側 (任意)</Field.Label>
+
+                              {/*
+                                * 非婚姻リレーションに切り替えたら値を残さない (superRefine 違反防止)。
+                                * 「指定なし」は空文字で表現し、保存時に undefined へ変換する。
+                                */}
+                              <Controller
+                                control={control}
+                                name="householdSide"
+                                render={({ field }) => (
+                                  <RadioGroup.Root
+                                    name={field.name}
+                                    onValueChange={({ value }): void => {
+                                      field.onChange(value === '' ? undefined : value);
+                                    }}
+                                    value={field.value ?? ''}
+                                  >
+                                    <Flex gap={2}>
+                                      <RadioGroup.Item value="">
+                                        <RadioGroup.ItemHiddenInput onBlur={field.onBlur} />
+                                        <RadioGroup.ItemIndicator />
+                                        <RadioGroup.ItemText>指定なし</RadioGroup.ItemText>
+                                      </RadioGroup.Item>
+
+                                      <RadioGroup.Item value={HouseholdSide.PERSON1}>
+                                        <RadioGroup.ItemHiddenInput onBlur={field.onBlur} />
+                                        <RadioGroup.ItemIndicator />
+
+                                        <RadioGroup.ItemText>
+                                          {`${selectedRelationType.person1Label}側`}
+                                        </RadioGroup.ItemText>
+                                      </RadioGroup.Item>
+
+                                      <RadioGroup.Item value={HouseholdSide.PERSON2}>
+                                        <RadioGroup.ItemHiddenInput onBlur={field.onBlur} />
+                                        <RadioGroup.ItemIndicator />
+
+                                        <RadioGroup.ItemText>
+                                          {`${selectedRelationType.person2Label}側`}
+                                        </RadioGroup.ItemText>
+                                      </RadioGroup.Item>
+                                    </Flex>
+                                  </RadioGroup.Root>
+                                )}
+                                shouldUnregister
+                              />
+
+                              <Field.ErrorText>{errors.householdSide?.message}</Field.ErrorText>
                             </Field.Root>
                           )
                           : null}

--- a/src/components/relation/RelationPersonField.tsx
+++ b/src/components/relation/RelationPersonField.tsx
@@ -75,9 +75,11 @@ export function RelationPersonField({
         )}
       />
 
-      {errorMessages.map((message, i) => (
-        <Field.ErrorText key={`${name}-err-${i.toString()}`}>{message}</Field.ErrorText>
-      ))}
+      {errorMessages
+        .filter((message): message is string => message !== undefined)
+        .map((message) => (
+          <Field.ErrorText key={`${name}-${message}`}>{message}</Field.ErrorText>
+        ))}
     </Field.Root>
   );
 }

--- a/src/components/relation/RelationPersonField.tsx
+++ b/src/components/relation/RelationPersonField.tsx
@@ -39,7 +39,6 @@ export function RelationPersonField({
         render={({ field }) => (
           <Select.Root
             collection={personCollection}
-            defaultValue={field.value}
             name={field.name}
             onInteractOutside={field.onBlur}
             onValueChange={({ value }): void => { field.onChange(value); }}

--- a/src/components/relation/RelationPersonField.tsx
+++ b/src/components/relation/RelationPersonField.tsx
@@ -1,0 +1,84 @@
+import { Field, type ListCollection, Portal, Select } from '@chakra-ui/react';
+import React from 'react';
+import { type Control, Controller } from 'react-hook-form';
+
+import { type Relation } from '@/schemas/relationSchema';
+
+interface PersonOption {
+  label: string;
+  value: string;
+}
+
+interface Props {
+  control: Control<Relation>;
+  name: 'persons.personId1' | 'persons.personId2';
+  label: string;
+  personCollection: ListCollection<PersonOption>;
+  invalid: boolean;
+  errorMessages: (string | undefined)[];
+}
+
+/*
+ * 関係追加フォームの人物セレクタ。person1 / person2 で同一構造なので共通化している。
+ */
+export function RelationPersonField({
+  control,
+  name,
+  label,
+  personCollection,
+  invalid,
+  errorMessages,
+}: Props): React.ReactNode {
+  return (
+    <Field.Root invalid={invalid}>
+      <Field.Label>{label}</Field.Label>
+
+      <Controller
+        control={control}
+        name={name}
+        render={({ field }) => (
+          <Select.Root
+            collection={personCollection}
+            defaultValue={field.value}
+            name={field.name}
+            onInteractOutside={field.onBlur}
+            onValueChange={({ value }): void => { field.onChange(value); }}
+            value={field.value}
+          >
+            <Select.HiddenSelect />
+
+            <Select.Control>
+              <Select.Trigger>
+                <Select.ValueText placeholder={label} />
+              </Select.Trigger>
+
+              <Select.IndicatorGroup>
+                <Select.Indicator />
+              </Select.IndicatorGroup>
+            </Select.Control>
+
+            <Portal>
+              <Select.Positioner>
+                <Select.Content zIndex={1500}>
+                  {personCollection.items.map((person) => (
+                    <Select.Item
+                      item={person}
+                      key={person.value}
+                    >
+                      {person.label}
+                      <Select.ItemIndicator />
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Positioner>
+            </Portal>
+          </Select.Root>
+        )}
+      />
+
+      {errorMessages.map((message, i) => (
+        <Field.ErrorText key={`${name}-err-${i.toString()}`}>{message}</Field.ErrorText>
+      ))}
+    </Field.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- 婚姻関係 (夫婦/事実婚) を選んだときだけ「家系を継ぐ側」のラジオ (指定なし / 夫側 / 妻側) を表示
- 「指定なし」は空文字で表し保存時に `undefined` へ変換。非婚姻に切り替えたら `shouldUnregister` で値を残さない (#146 の superRefine 違反防止)
- `AddRelationDialog` が `max-lines` (300) を超えたため、重複していた人物 Select を `RelationPersonField` コンポーネントに抽出

## 検証
- ローカルで Docker (公式イメージ) を使い、ダイアログを開いて関係セレクトを展開したスクショで UI 描画を目視確認 (ダイアログ + ドロップダウン + ラジオが正しく出る)
- householdSide → primary 親の反映は #146 の ownership / buildUnits 単体テストでカバー済み
- E2E は初期状態 (婚姻未選択で householdSide/divorced が非表示) を検証。**婚姻選択後の表示の自動検証は見送り** — Chakra v3 Select のポータル listbox が headless Playwright で actionable 判定されず安定して駆動できなかったため (click/force/keyboard/native select すべて不安定)。この点は別途 a11y/操作性の改善余地として認識

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] `yarn test` (100/100)
- [x] `yarn e2e` (6/6)
- [x] `yarn build`
- [x] ダイアログ UI をスクショで目視確認

Closes #163