### PR TITLE
[#167] Dialog 内 Select の aria-hidden 化を解消 (Portal 除去)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@
 - Playwright の project で機能 E2E (`yarn e2e` = `--project=e2e`) と VRT (`yarn vrt` = `--project=vrt`) を分離。`visual.spec.ts` のみ vrt project。新規の機能 E2E は `e2e` project が自動で拾う (visual.spec.ts 以外)
 - VRT の baseline はフォント差で誤検知しないよう**必ず公式 Docker イメージ `mcr.microsoft.com/playwright:v<version>-noble` + `fonts-noto-cjk`** で生成・比較する。ローカルの素の chromium で生成すると日本語が豆腐になり CI と一致しない。更新は `VRT Update Baselines` ワークフロー (手動) → artifact を展開し、最終的に `e2e/__screenshots__/visual.spec.ts/*.png` の配置になるよう commit (二重階層 `e2e/__screenshots__/e2e/...` にしないこと)
 - VRT ジョブは比較とは別に「現在の見た目」を `vrt-current` artifact として毎 PR 出力する。`gh run download <run-id> -n vrt-current` で取得して見た目レビューに使う (リグレッション差分の有無に依存せず取れる)。baseline 更新の `vrt-baselines` とは artifact 名で区別 (`vrt-run.yml` の `snapshot-artifact-name` input)
-- **Chakra v3 の `Select` (特に Dialog 内・ポータルの listbox) は headless Playwright で安定して駆動できない**。listbox が開き option も a11y ツリーに出るが、click/force click/keyboard/native `<select>` の selectOption いずれも不安定 (描画自体は正しく、実ブラウザでは動く)。`reducedMotion: 'reduce'` でも改善せず (アニメーションが原因ではない。Dialog の focus-trap と body 直下ポータルの相互作用が疑わしい)。E2E では Select の選択を伴うフローは避け、ロジックは単体テスト + 必要なら Docker スクショの目視で担保する。`Input` / `RadioGroup` 系 (PersonDialog) は問題なく駆動できる
+- **Dialog 内の Chakra `Select` は `<Portal>` でラップしない** (#167)。Portal で body 直下に出すと Chakra `Dialog` の focus-trap が listbox の祖先を `aria-hidden="true"` 化し、スクリーンリーダーからも E2E (`getByRole('option')`) からも不可視になる (実ブラウザのマウス操作だけは効くので気づきにくい)。`Select.Positioner` / `Select.Content` を Portal せず Dialog 内に直接置けば aria-hidden されず、SR でも E2E でも正常に動く。ダイアログ外の Select は Portal してよい。clipping は今のところ問題なし (はみ出して表示される)
 
 ### CSS / レイアウト
 - `<input type="file">` の change イベントは同じファイルを再選択しても発火しない。click 前に `inputRef.current.value = ''` でリセットする

--- a/e2e/family-tree.spec.ts
+++ b/e2e/family-tree.spec.ts
@@ -42,16 +42,17 @@ test('インポート後にノードをクリックすると編集ダイアロ�
   await expect(page.getByPlaceholder('姓', { exact: true })).toHaveValue('山田');
 });
 
-test('関係追加ダイアログの初期状態では「家系を継ぐ側」は出ない', async({ page }) => {
+test('関係追加で夫婦を選ぶと「家系を継ぐ側」が表示される', async({ page }) => {
   await page.getByRole('button', { name: '関係追加' }).click();
   const dialog = page.getByRole('dialog');
-  await expect(dialog.getByText('関係追加')).toBeVisible();
-
-  /*
-   * 婚姻関係を選ぶ前は householdSide / divorced は非表示。
-   * 婚姻選択後の表示は Chakra Select の駆動が headless で不安定なため E2E では検証しない。
-   * 値 → primary 親の反映は ownership / buildUnits の単体テストでカバー。
-   */
+  // 婚姻関係を選ぶ前は非表示
   await expect(dialog.getByText('家系を継ぐ側 (任意)')).toBeHidden();
-  await expect(dialog.getByText('離婚済み')).toBeHidden();
+  // 関係セレクトを開いて「夫婦」を選択
+  const relationTrigger = dialog.locator('[data-part="trigger"]').first();
+  await relationTrigger.click();
+  await page.getByRole('option', { name: '夫婦' }).click();
+  // 婚姻なので「家系を継ぐ側」のラジオが出る
+  await expect(dialog.getByText('家系を継ぐ側 (任意)')).toBeVisible();
+  await expect(dialog.getByText('夫側')).toBeVisible();
+  await expect(dialog.getByText('妻側')).toBeVisible();
 });

--- a/src/components/relation/AddRelationDialog.tsx
+++ b/src/components/relation/AddRelationDialog.tsx
@@ -108,21 +108,19 @@ export function AddRelationDialog({ isOpen, onOpenChange }: AddRelationDialogPro
                             </Select.IndicatorGroup>
                           </Select.Control>
 
-                          <Portal>
-                            <Select.Positioner>
-                              <Select.Content zIndex={1500}>
-                                {relationTypeCollection.items.map((relationType) => (
-                                  <Select.Item
-                                    item={relationType}
-                                    key={relationType.value}
-                                  >
-                                    {relationType.label}
-                                    <Select.ItemIndicator />
-                                  </Select.Item>
-                                ))}
-                              </Select.Content>
-                            </Select.Positioner>
-                          </Portal>
+                          <Select.Positioner>
+                            <Select.Content zIndex={1500}>
+                              {relationTypeCollection.items.map((relationType) => (
+                                <Select.Item
+                                  item={relationType}
+                                  key={relationType.value}
+                                >
+                                  {relationType.label}
+                                  <Select.ItemIndicator />
+                                </Select.Item>
+                              ))}
+                            </Select.Content>
+                          </Select.Positioner>
                         </Select.Root>
                       )}
                     />

--- a/src/components/relation/RelationPersonField.tsx
+++ b/src/components/relation/RelationPersonField.tsx
@@ -1,4 +1,4 @@
-import { Field, type ListCollection, Portal, Select } from '@chakra-ui/react';
+import { Field, type ListCollection, Select } from '@chakra-ui/react';
 import React from 'react';
 import { type Control, Controller } from 'react-hook-form';
 
@@ -56,21 +56,24 @@ export function RelationPersonField({
               </Select.IndicatorGroup>
             </Select.Control>
 
-            <Portal>
-              <Select.Positioner>
-                <Select.Content zIndex={1500}>
-                  {personCollection.items.map((person) => (
-                    <Select.Item
-                      item={person}
-                      key={person.value}
-                    >
-                      {person.label}
-                      <Select.ItemIndicator />
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select.Positioner>
-            </Portal>
+            {/*
+              * Dialog 内では Portal で body 直下に出すと dialog の focus-trap に
+              * aria-hidden 化され、listbox が SR/E2E から不可視になる (#167)。
+              * Portal せず dialog 内にレンダリングする。
+              */}
+            <Select.Positioner>
+              <Select.Content zIndex={1500}>
+                {personCollection.items.map((person) => (
+                  <Select.Item
+                    item={person}
+                    key={person.value}
+                  >
+                    {person.label}
+                    <Select.ItemIndicator />
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Positioner>
           </Select.Root>
         )}
       />


### PR DESCRIPTION
## Summary
#163 で「Dialog 内の Chakra Select が Playwright で駆動できない」問題を調査し、根本原因を特定・修正した。

## 根本原因
Dialog 内の Select を `<Portal>` で body 直下にレンダリングすると、Chakra `Dialog` の focus-trap (ダイアログ外要素を aria-hidden 化する挙動) が、**ポータルされた listbox の祖先を `aria-hidden="true"` にしてしまう**。結果:
- スクリーンリーダーから開いている listbox の選択肢が見えない (**a11y バグ**)
- Playwright の `getByRole('option')` も a11y ツリーを使うため option を見つけられず E2E が組めない
- 実ブラウザのマウス操作だけは効くので気づきにくかった

調査ログ (probe スクリプトで計測):
- listbox 自体は `visible` / `pointer-events:auto` / ヒットテストも通る
- だが祖先 positioner が `aria-hidden="true"` → role クエリが空振り
- `reducedMotion` は無関係 (検証済み)

## 修正
- `AddRelationDialog` の関係タイプ Select と `RelationPersonField` の人物 Select から内側の `<Portal>` を除去し、Dialog 内に直接レンダリング
- aria-hidden が解消し、SR でも E2E でも option にアクセス可能に
- clipping は発生しない (はみ出して表示。スクショ確認済み)
- #163 で見送った「夫婦選択 → 家系を継ぐ側 表示」の E2E を本来の形に復活
- CLAUDE.md の該当記述を「解決策」に更新

## Test plan
- [x] `yarn lint` (0 errors / 10 warnings)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] `yarn test` (100/100)
- [x] `yarn e2e` (6/6 — Select 駆動の E2E が通る)
- [x] `yarn build`
- [x] ドロップダウン表示を Docker スクショで目視確認 (clipping なし)

Closes #167