### PR TITLE
[#169] AddRelationDialog のフィールド間に余白を追加

### DIFF
--- a/src/components/relation/AddRelationDialog.tsx
+++ b/src/components/relation/AddRelationDialog.tsx
@@ -79,7 +79,10 @@ export function AddRelationDialog({ isOpen, onOpenChange }: AddRelationDialogPro
               }}
             >
               <Dialog.Body>
-                <Flex direction="column">
+                <Flex
+                  direction="column"
+                  gap={4}
+                >
                   <Field.Root invalid={Boolean(errors.relationType)}>
 
                     <Field.Label>関係</Field.Label>


### PR DESCRIPTION
## Summary

関係追加ダイアログの各フィールド (関係 / 人物1 / 人物2 / 離婚済み / 家系を継ぐ側) が間隔ゼロで詰まっていた。`Dialog.Body` 内の `<Flex direction="column">` に `gap` が無かったため。PersonDialog と同じ `gap={4}` を指定して余白を揃えた。

## Test plan

- [x] `yarn lint` (0 errors)
- [x] `yarn test`
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] Docker スクショで各フィールドに縦余白が出ることを確認

Closes #169