### PR TITLE
[#171] 家系図フィルタの Select ラベル見切れを解消

### DIFF
--- a/src/components/familyTree/FamilyTreeFilter.tsx
+++ b/src/components/familyTree/FamilyTreeFilter.tsx
@@ -83,7 +83,7 @@ export function FamilyTreeFilter({ people, criteria, onChange }: Props): React.R
         onValueChange={({ value }): void => { handlePersonChange(value); }}
         size="sm"
         value={selectedPerson}
-        width="180px"
+        width="220px"
       >
         <Select.HiddenSelect />
 
@@ -120,7 +120,7 @@ export function FamilyTreeFilter({ people, criteria, onChange }: Props): React.R
         onValueChange={({ value }): void => { handleScopeChange(value); }}
         size="sm"
         value={selectedScope}
-        width="130px"
+        width="150px"
       >
         <Select.HiddenSelect />
 


### PR DESCRIPTION
## Summary

家系図フィルタの 2 つの Select でラベルが幅不足で見切れていた (「起点人物を選択」→「起点人物を…」、「祖先と子孫」→「祖先と…」) のを解消した。

- 起点人物 Select: `width` 180px → 220px (人物名「山田 太郎」等も収まる余裕を確保)
- 範囲 Select: `width` 130px → 150px (「祖先と子孫」が収まる)

## Test plan

- [x] `yarn lint` (0 errors)
- [x] `yarn test` (103 passed)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] Docker (CJK フォント) スクショで両ラベルが省略されず表示されることを確認

Closes #171