### PR TITLE
[#172] 関係追加ダイアログの Select の視認性を改善

### DIFF
--- a/src/components/relation/AddRelationDialog.tsx
+++ b/src/components/relation/AddRelationDialog.tsx
@@ -104,7 +104,7 @@ export function AddRelationDialog({ isOpen, onOpenChange }: AddRelationDialogPro
                           <Select.Control>
                             {/*
                               * 未選択時も入力可能と分かるよう、枠線を明示しつつ
-                              * 背景を透明にして入力欄 (白背景) と見た目を揃える (#172)。
+                              * 背景を透明にして他の入力欄と見た目を揃える (#172)。
                               */}
                             <Select.Trigger
                               bg="transparent"

--- a/src/components/relation/AddRelationDialog.tsx
+++ b/src/components/relation/AddRelationDialog.tsx
@@ -102,7 +102,15 @@ export function AddRelationDialog({ isOpen, onOpenChange }: AddRelationDialogPro
                           <Select.HiddenSelect />
 
                           <Select.Control>
-                            <Select.Trigger>
+                            {/*
+                              * 未選択時も入力可能と分かるよう、枠線を明示しつつ
+                              * 背景を透明にして入力欄 (白背景) と見た目を揃える (#172)。
+                              */}
+                            <Select.Trigger
+                              bg="transparent"
+                              borderColor="border.emphasized"
+                              borderWidth="1px"
+                            >
                               <Select.ValueText placeholder="関係" />
                             </Select.Trigger>
 

--- a/src/components/relation/RelationPersonField.tsx
+++ b/src/components/relation/RelationPersonField.tsx
@@ -49,7 +49,7 @@ export function RelationPersonField({
             <Select.Control>
               {/*
                 * 未選択時も入力可能と分かるよう、枠線を明示しつつ
-                * 背景を透明にして入力欄 (白背景) と見た目を揃える (#172)。
+                * 背景を透明にして他の入力欄と見た目を揃える (#172)。
                 */}
               <Select.Trigger
                 bg="transparent"

--- a/src/components/relation/RelationPersonField.tsx
+++ b/src/components/relation/RelationPersonField.tsx
@@ -47,7 +47,15 @@ export function RelationPersonField({
             <Select.HiddenSelect />
 
             <Select.Control>
-              <Select.Trigger>
+              {/*
+                * 未選択時も入力可能と分かるよう、枠線を明示しつつ
+                * 背景を透明にして入力欄 (白背景) と見た目を揃える (#172)。
+                */}
+              <Select.Trigger
+                bg="transparent"
+                borderColor="border.emphasized"
+                borderWidth="1px"
+              >
                 <Select.ValueText placeholder={label} />
               </Select.Trigger>
 


### PR DESCRIPTION
## Summary

関係追加ダイアログの「夫」「妻」(および「関係」) の Select が、未選択時に枠が薄く・背景がグレーのため disabled と区別しにくかったのを改善した。

調査の結果、枠線よりも **グレー背景 (`rgb(249,249,249)`)** が「非活性っぽさ」の主因だった (人物ダイアログの入力欄は背景透明・白)。

- `Select.Trigger` に `borderColor="border.emphasized"` + `borderWidth="1px"` を明示 (Checkbox #163 と同じ方針)
- `bg="transparent"` で背景を入力欄と揃える
- `border.emphasized` はセマンティックトークンのためライト/ダーク両対応

## Test plan

- [x] `yarn lint` (0 errors)
- [x] `yarn test` (103 passed)
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] Docker (CJK フォント) スクショで **ライトモード** の Select が白背景＋視認できる枠になることを確認
- [x] `colorScheme: 'dark'` で **ダークモード** も枠が視認でき (`border.emphasized` → `rgb(63,63,70)`)、背景が馴染むことを確認

Closes #172