### PR TITLE
[#164] 家系を継ぐ側を婚姻線の左に配置する

### DIFF
--- a/src/components/familyTree/layout/ownership.ts
+++ b/src/components/familyTree/layout/ownership.ts
@@ -8,10 +8,14 @@ export interface OwnershipResult {
 
 /*
  * householdHeadPersonId が指定されていれば、その人物を先頭にした personIds 順を返す。
- * 親ユニット探索はこの順で行われ、先に見つかった親ユニットが primary になるため、
- * 「家系を継ぐ側」の親系統が primary に選ばれる。視覚上の personIds 順は変えない。
+ * この順は 2 箇所で使う:
+ *   1. 親ユニット探索 — 先に見つかった親ユニットが primary になるため、「家系を継ぐ側」の
+ *      親系統が primary に選ばれる。
+ *   2. placement の左右配置 — 継ぐ側を先頭にすることで婚姻線の左に配置され、嫁入り/婿入りを
+ *      ラベル無しで視覚的に表現する (#164)。
+ * householdHeadPersonId 未指定なら従来どおり personId1 が先頭 (= 左)。
  */
-function orderedPersonIds(unit: Unit): string[] {
+export function orderedPersonIds(unit: Unit): string[] {
   const head = unit.householdHeadPersonId;
   if (head === null || !unit.personIds.includes(head)) {
     return unit.personIds;

--- a/src/components/familyTree/layout/placement.ts
+++ b/src/components/familyTree/layout/placement.ts
@@ -9,7 +9,7 @@ import {
   type Unit,
   UNIT_GAP,
 } from '@/components/familyTree/layout/internalTypes';
-import { findAnchorPersonId } from '@/components/familyTree/layout/ownership';
+import { findAnchorPersonId, orderedPersonIds } from '@/components/familyTree/layout/ownership';
 import { unitOwnWidth } from '@/components/familyTree/layout/subtreeWidth';
 import { type ChildLinkLayout } from '@/components/familyTree/types';
 
@@ -20,7 +20,8 @@ function placeUnitPersons(
   ctx: PlacementCtx,
 ): void {
   let px = unitLeftX;
-  for (const pid of unit.personIds) {
+  // 継ぐ側 (household head) を左に配置するため head-first 順で並べる (#164)
+  for (const pid of orderedPersonIds(unit)) {
     ctx.nodes.push({
       personId: pid,
       x: px,

--- a/src/components/familyTree/layout/secondaryParents.test.ts
+++ b/src/components/familyTree/layout/secondaryParents.test.ts
@@ -150,6 +150,44 @@ describe('buildSecondaryParentEdges', () => {
     expect(edges[0].adopted).toBe(true);
   });
 
+  it('couple 親で継ぐ側 (person2) が左スロットでもアンカーは婚姻線中央になる (#164)', () => {
+    // personIds=[HUSBAND, WIFE] だが WIFE を左 (x=0)、HUSBAND を右に配置したケース
+    const couple = coupleUnit('u-couple', ID.HUSBAND, ID.WIFE);
+    const child = singleUnit('u-child', ID.CHILD);
+    const childToParents = new Map<string, ParentLink[]>([
+      [
+        ID.CHILD, [
+          { parentId: ID.WIFE,
+            adopted: false },
+        ],
+      ],
+    ]);
+    const personPositions = new Map<string, PersonPosition>([
+      [
+        ID.WIFE, { x: 0,
+          y: 0 },
+      ],
+      [
+        ID.HUSBAND, { x: PERSON_WIDTH + COUPLE_GAP,
+          y: 0 },
+      ],
+      [
+        ID.CHILD, { x: 150,
+          y: 200 },
+      ],
+    ]);
+    const ctx = buildCtx(
+      [couple, child],
+      new Map([[child.id, [couple.id]]]),
+      childToParents,
+      personPositions,
+    );
+    const edges = buildSecondaryParentEdges(ctx);
+    expect(edges).toHaveLength(1);
+    // 左端 (min x = 0) 起点の婚姻線中央。personIds[0]=HUSBAND の右スロット x ではない。
+    expect(edges[0].parentAnchorX).toBe(PERSON_WIDTH + (COUPLE_GAP / 2));
+  });
+
   it('座標が未確定の場合は edge をスキップする', () => {
     const outsider = singleUnit('u-outsider', ID.OUTSIDER);
     const child = singleUnit('u-child', ID.CHILD);

--- a/src/components/familyTree/layout/secondaryParents.ts
+++ b/src/components/familyTree/layout/secondaryParents.ts
@@ -23,8 +23,14 @@ function getParentUnitOrigin(
   if (positions.length === 0) {
     return null;
   }
+
+  /*
+   * householdSide 指定時は person1 が左スロットとは限らない (#164 で継ぐ側を左に配置)。
+   * computeParentAnchor は unit の左端を起点に婚姻線中央を計算するため、personIds[0] では
+   * なく実際の最小 x を unit 左端として渡す。couple の 2 人は同じ y なので y は先頭でよい。
+   */
   return {
-    leftX: positions[0].x,
+    leftX: Math.min(...positions.map((p) => p.x)),
     y: positions[0].y,
   };
 }

--- a/src/components/familyTree/layoutFamilyTree.test.ts
+++ b/src/components/familyTree/layoutFamilyTree.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { layoutFamilyTree } from '@/components/familyTree/layoutFamilyTree';
 import { type Person, Sex } from '@/schemas/personSchema';
-import { type Relation, RelationType } from '@/schemas/relationSchema';
+import { HouseholdSide, type Relation, RelationType } from '@/schemas/relationSchema';
 
 const ID = {
   HUSBAND: '11111111-1111-4111-8111-111111111111',
@@ -104,6 +104,26 @@ describe('layoutFamilyTree', () => {
       throw new Error('期待した子ノードが見つかりません');
     }
     expect(oldNode.x).toBeGreaterThan(newNode.x);
+  });
+
+  it('婚姻線の左右は継ぐ側に従う: 未指定は person1, person2 指定なら継ぐ側が左 (#164)', () => {
+    const people = [person(ID.HUSBAND, '1970-01-01'), person(ID.WIFE, '1972-01-01')];
+    const xOf = (rel: Relation, id: string): number => {
+      const node = layoutFamilyTree(people, [rel]).nodes.find((n) => n.personId === id);
+      if (node === undefined) {
+        throw new Error('期待したノードが見つかりません');
+      }
+      return node.x;
+    };
+    // 未指定: person1 (HUSBAND) が左
+    const plain = marriedRel(ID.REL_MARRIED, ID.HUSBAND, ID.WIFE);
+    expect(xOf(plain, ID.HUSBAND)).toBeLessThan(xOf(plain, ID.WIFE));
+    // person2 指定: 継ぐ側 (WIFE) が左
+    const headRel: Relation = {
+      ...plain,
+      householdSide: HouseholdSide.PERSON2,
+    };
+    expect(xOf(headRel, ID.WIFE)).toBeLessThan(xOf(headRel, ID.HUSBAND));
   });
 
   it('存在しない人物を参照する relation は無視する', () => {


### PR DESCRIPTION
## Summary

婚姻線付近に「嫁入り/婿入り」を示す機能 (#164)。当初はテキストラベル描画案だったが、issue のコメントを受けて **家系を継ぐ側 (householdHead) を婚姻線の左に配置する視覚規約** で表現する方針に変更した (テキストラベルは描画しない)。

- `householdHeadPersonId` をこれまで親系統の primary 判定にのみ使っていたが、`placement` の左右配置にも反映
- `ownership` 既存の head-first 順 `orderedPersonIds` を export し、`placement.placeUnitPersons` で共有 (ロジック重複なし)
- `householdSide` 未指定時は従来どおり person1 が左 (挙動不変)

### 方針変更について
- テキストラベル描画 / 性別ベースの嫁入り・婿入り導出は実装しない (左右配置だけで表現)
- VRT baseline 更新も不要 (サンプルデータに `householdSide` 指定が無く、デフォルト表示は変わらない)
- 経緯: #164 のコメント (「ラベル必要？」「継ぐ側を左にすればよさそう」) を採用

## Test plan

- [x] `yarn lint` (0 errors)
- [x] `yarn test` (104 passed) — `layoutFamilyTree.test.ts` に「継ぐ側が左に来る」ケースを追加
- [x] `yarn tsc -p tsconfig.app.json --noEmit`
- [x] Docker (CJK フォント) スクショで婿入りケース (継ぐ側=妻) を **ライト/ダーク両モード** で確認: 継ぐ側 (花子) が左、婚入り側 (田中 太郎) が右、親線が継ぐ側に接続

Closes #164

## 既知の制限

- 本 PR の「継ぐ側を左」は **最初の婚姻 (couple Unit を形成する婚姻) のみ** 対応。再婚 (secondary marriage) では householdSide が反映されない。複数回の婚姻で継いだり継がなかったりするケースは別途対応 → #176
